### PR TITLE
Add the connection timeout error

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -16,7 +16,7 @@ module Beetle
         Bunny::ConnectionError, Bunny::ForcedChannelCloseError, Bunny::ForcedConnectionCloseError,
         Bunny::MessageError, Bunny::ProtocolError, Bunny::ServerDownError, Bunny::UnsubscribeError,
         Bunny::AcknowledgementError, Qrack::BufferOverflowError, Qrack::InvalidTypeError,
-        Errno::EHOSTUNREACH, Errno::ECONNRESET
+        Errno::EHOSTUNREACH, Errno::ECONNRESET, Qrack::ConnectionTimeout
       ]
     end
 


### PR DESCRIPTION
When adding a `config.publishing_timeout` value I noticed that the exception that is raised for a timeout isn't being properly caught.
