### PR TITLE
Fixed issue with duplicate failed messages not being removed from the queue

### DIFF
--- a/features/support/test_daemons/redis.conf.erb
+++ b/features/support/test_daemons/redis.conf.erb
@@ -166,11 +166,6 @@ appendfsync everysec
 
 ############################### ADVANCED CONFIG ###############################
 
-# Glue small output buffers together in order to send small replies in a
-# single TCP packet. Uses a bit more CPU but most of the times it is a win
-# in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
-
 # Use object sharing. Can save a lot of memory if you have many common
 # string in your dataset, but performs lookups against the shared objects
 # pool so it uses more CPU and can be a bit slower. Usually it's a good

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -263,10 +263,12 @@ module Beetle
       elsif !timed_out?
         RC::HandlerNotYetTimedOut
       elsif attempts_limit_reached?
+        completed!
         ack!
         logger.warn "Beetle: reached the handler execution attempts limit: #{attempts_limit} on #{msg_id}"
         RC::AttemptsLimitReached
       elsif exceptions_limit_reached?
+        completed!
         ack!
         logger.warn "Beetle: reached the handler exceptions limit: #{exceptions_limit} on #{msg_id}"
         RC::ExceptionsLimitReached
@@ -306,10 +308,12 @@ module Beetle
     def handler_failed!(result)
       increment_exception_count!
       if attempts_limit_reached?
+        completed!
         ack!
         logger.debug "Beetle: reached the handler execution attempts limit: #{attempts_limit} on #{msg_id}"
         RC::AttemptsLimitReached
       elsif exceptions_limit_reached?
+        completed!
         ack!
         logger.debug "Beetle: reached the handler exceptions limit: #{exceptions_limit} on #{msg_id}"
         RC::ExceptionsLimitReached

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -348,7 +348,7 @@ module Beetle
 
       proc = lambda {|*args| raise "crash"}
       s = sequence("s")
-      message.expects(:completed!).never
+      message.expects(:completed!).once
       header.expects(:ack)
       assert_equal RC::ExceptionsLimitReached, message.__send__(:process_internal, proc)
     end
@@ -363,7 +363,7 @@ module Beetle
 
       proc = lambda {|*args| raise "crash"}
       s = sequence("s")
-      message.expects(:completed!).never
+      message.expects(:completed!).once
       header.expects(:ack)
       assert_equal RC::AttemptsLimitReached, message.__send__(:process_internal, proc)
     end


### PR DESCRIPTION
A duplicate of a previous message that has eventually failed (due to the execution or exception limit been exceeded) was not ACKed thus preventing it being removed from the queue and repeatedly reprocessed until the time out limit was reached.  This also caused a sleep of 1 second until the next message (from either queue) was processed.

In RabbitMQ v >=2.7.0 this was a bigger problem as the message would stay at the front of the queue thus blocking other messages, and therefore the 1 second sleep would be continuously repeated until the time out limit was reached (default 10 minutes) and the message finally removed.
