### PR TITLE
Add Message#key method as a shortcut to get the routing key

### DIFF
--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -100,6 +100,11 @@ module Beetle
       opts
     end
 
+    # the routing key
+    def key
+      header.routing_key
+    end
+
     # unique message id. used to form various keys in the deduplication store.
     def msg_id
       @msg_id ||= "msgid:#{queue}:#{uuid}"

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -774,4 +774,13 @@ module Beetle
     end
   end
 
+
+  class KeyTest < Test::Unit::TestCase
+    test "returns the routing key" do
+      header = header_with_params({})
+      header.stubs(:routing_key).returns("foo")
+      message = Message.new("somequeue", header, "")
+      assert_equal "foo", message.key
+    end
+  end
 end


### PR DESCRIPTION
I found myself writing code like `message.header.routing_key` in my handlers quite frequently, so I think a shortcut is in order.
