### PR TITLE
add missing import to configuration

### DIFF
--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'yaml'
 
 module Beetle
   class Configuration


### PR DESCRIPTION
fixes following bug, when yaml was not loaded yet:
`E, [2014-12-01T17:02:30.268672 #12409] ERROR -- : Error loading beetle config file 'beetle.yml': uninitialized constant Beetle::Configuration::YAML`
