### PR TITLE
Add the abillity to add custom headers when publishing an AMQP message

### DIFF
--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -34,7 +34,7 @@ module Beetle
   # AMQP options for queue bindings
   QUEUE_BINDING_KEYS      = [:key, :no_wait]
   # AMQP options for message publishing
-  PUBLISHING_KEYS         = [:key, :mandatory, :immediate, :persistent, :reply_to]
+  PUBLISHING_KEYS         = [:key, :mandatory, :immediate, :persistent, :reply_to, :headers]
   # AMQP options for subscribing to queues
   SUBSCRIPTION_KEYS       = [:ack, :key]
 

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -92,11 +92,12 @@ module Beetle
       expires_at = now + (opts[:ttl] || DEFAULT_TTL)
       opts = opts.slice(*PUBLISHING_KEYS)
       opts[:message_id] = generate_uuid.to_s
-      opts[:headers] = {
+      headers = (opts[:headers] ||= {})
+      headers.merge!(
         :format_version => FORMAT_VERSION.to_s,
         :flags => flags.to_s,
         :expires_at => expires_at.to_s
-      }
+      )
       opts
     end
 

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -64,9 +64,23 @@ module Beetle
 
     test "the publishing options must only include string values" do
       options = Message.publishing_options(:redundant => true, :mandatory => true, :bogus => true)
+
       assert options[:headers].all? {|_, param| param.is_a?(String)}
     end
 
+    test "the publishing options support adding custom headers" do
+      options = Message.publishing_options(
+        :redundant => true,
+        :headers => {
+          :sender_id => "SENDER_ID",
+          :sender_action => "SENDER_ACTION"
+        }
+      )
+
+      assert_equal "1", options[:headers][:flags]
+      assert_equal "SENDER_ID", options[:headers][:sender_id]
+      assert_equal "SENDER_ACTION", options[:headers][:sender_action]
+    end
   end
 
   class KeyManagementTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
This patch adds the ability to supply custom headers to beetle when using `client.publish`.

Let's talk about it. Behaviour has been verified on a XING sandbox