### PR TITLE
Improve support for broker migrations

### DIFF
--- a/lib/beetle/client.rb
+++ b/lib/beetle/client.rb
@@ -267,6 +267,15 @@ module Beetle
       end
     end
 
+    def reset!
+      stop_publishing if @publisher
+      stop_listening if @subscriber
+      config.reload
+    ensure
+      @publisher = nil
+      @subscriber = nil
+    end
+
     private
 
     def determine_queue_names(queues)
@@ -311,14 +320,6 @@ module Beetle
 
     def subscriber
       @subscriber ||= Subscriber.new(self)
-    end
-
-    def reset!
-      stop_publishing if @publisher
-      stop_listening if @subscriber
-    ensure
-      @publisher = nil
-      @subscriber = nil
     end
 
     def queue_name_for_tracing(queue)

--- a/lib/beetle/client.rb
+++ b/lib/beetle/client.rb
@@ -313,6 +313,14 @@ module Beetle
       @subscriber ||= Subscriber.new(self)
     end
 
+    def reset!
+      stop_publishing if @publisher
+      stop_listening if @subscriber
+    ensure
+      @publisher = nil
+      @subscriber = nil
+    end
+
     def queue_name_for_tracing(queue)
       "trace-#{queue}-#{Beetle.hostname}-#{$$}"
     end

--- a/lib/beetle/client.rb
+++ b/lib/beetle/client.rb
@@ -267,10 +267,13 @@ module Beetle
       end
     end
 
-    def reset!
+    def reset
       stop_publishing if @publisher
       stop_listening if @subscriber
       config.reload
+    rescue Exception => e
+      logger.warn("Error resetting client")
+      logger.warn(e)
     ensure
       @publisher = nil
       @subscriber = nil

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -58,6 +58,14 @@ module Beetle
     # external config file (defaults to <tt>no file</tt>)
     attr_reader :config_file
 
+    # returns the configured amqp brokers
+    def brokers
+      {
+        'servers' => self.servers,
+        'additional_subscription_servers' => self.additional_subscription_servers
+      }
+    end
+
     def initialize #:nodoc:
       self.system_name = "system"
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -98,6 +98,12 @@ module Beetle
       load_config
     end
 
+    # reloads the configuration from the configuration file
+    # if one is configured
+    def reload
+      load_config if @config_file
+    end
+
     def logger
       @logger ||=
         begin

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -111,7 +111,12 @@ module Beetle
 
     private
     def load_config
-      hash = YAML::load(ERB.new(IO.read(config_file)).result)
+      raw = ERB.new(IO.read(config_file)).result
+      hash = if config_file =~ /\.json$/
+               JSON.parse(raw)
+             else
+               YAML.load(raw)
+             end
       hash.each do |key, value|
         send("#{key}=", value)
       end

--- a/lib/beetle/redis_configuration_http_server.rb
+++ b/lib/beetle/redis_configuration_http_server.rb
@@ -39,10 +39,24 @@ module Beetle
         server_status(response, "plain")
       when '/initiate_master_switch'
         initiate_master_switch(response)
+      when '/brokers'
+        list_brokers(response)
       else
         not_found(response)
       end
       response.send_response
+    end
+
+    def list_brokers(response)
+      brokers = config_server.config.brokers
+      response.status = 200
+      if @http_headers =~ %r(application/json)
+        response.content_type 'application/json'
+        response.content = brokers.to_json
+      else
+        response.content_type 'text/yaml'
+        response.content = brokers.to_yaml
+      end
     end
 
     def server_status(response, type)

--- a/test/beetle/client_test.rb
+++ b/test/beetle/client_test.rb
@@ -204,6 +204,25 @@ module Beetle
   end
 
   class ClientTest < MiniTest::Unit::TestCase
+    test "#reset should stop subscriber and publisher" do
+      client = Client.new
+      client.send(:publisher).expects(:stop)
+      client.send(:subscriber).expects(:stop!)
+      client.reset
+    end
+
+    test "#reset should reload the configuration" do
+      client = Client.new
+      client.config.expects(:reload)
+      client.reset
+    end
+
+    test "#reset should not propagate exceptions" do
+      client = Client.new
+      client.expects(:config).raises(ArgumentError)
+      client.reset
+    end
+
     test "instantiating a client should not instantiate the subscriber/publisher" do
       Publisher.expects(:new).never
       Subscriber.expects(:new).never

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -32,5 +32,10 @@ module Beetle
       Logger.expects(:new).with(file).returns(stub_everything)
       config.logger
     end
+
+    test "#brokers returns a hash of the configured brokers" do
+      config = Configuration.new
+      assert_equal({"servers"=>"localhost:5672", "additional_subscription_servers"=>""}, config.brokers)
+    end
   end
 end

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -37,5 +37,35 @@ module Beetle
       config = Configuration.new
       assert_equal({"servers"=>"localhost:5672", "additional_subscription_servers"=>""}, config.brokers)
     end
+
+    test "#config_file can be a JSON file" do
+      file = '/path/to/file.json'
+      config = Configuration.new
+      IO.expects(:read).with(file).returns(
+        {
+          servers: 'localhost:5772',
+          additional_subscription_servers: '10.0.0.1:3001'
+        }.to_json)
+
+      config.config_file = file
+
+      assert_equal "localhost:5772", config.servers
+      assert_equal "10.0.0.1:3001", config.additional_subscription_servers
+    end
+
+    test "#config_file can be a YAML file" do
+      file = '/path/to/file.yml'
+      config = Configuration.new
+      IO.expects(:read).with(file).returns(
+        {
+          servers: 'localhost:5772',
+          additional_subscription_servers: '10.0.0.1:3001'
+        }.to_yaml)
+
+      config.config_file = file
+
+      assert_equal "localhost:5772", config.servers
+      assert_equal "10.0.0.1:3001", config.additional_subscription_servers
+    end
   end
 end


### PR DESCRIPTION
This pull request contains adds 3 things:

* a new endpoint `/brokers` in the embedded http server of the redis_configuration_server. It will serve the configuration fields `servers` and `additional_subscription_servers`. By default the endpoint serves its content in the format `text/yaml`, but also supports the JSON format if requested via `application/json`.

* The configuration was updated to also support JSON configuration files.

* A new `reset` method was added to `Beetle::Client` which forces the client to shut down it's publisher and subscriber instances and reload the configuration