### PR TITLE
Relax log level for redundant publishing warning

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -60,7 +60,7 @@ module Beetle
 
     def publish_with_redundancy(exchange_name, message_name, data, opts) #:nodoc:
       if @servers.size < 2
-        logger.error "Beetle: at least two active servers are required for redundant publishing"
+        logger.warn "Beetle: at least two active servers are required for redundant publishing"
         return publish_with_failover(exchange_name, message_name, data, opts)
       end
       published = []


### PR DESCRIPTION
People were often confused by seeing errors being logged during a planned broker restart (when using two brokers in total).
Logging a warning should be enough here, since the message can still be published to one server.

@skaes, @BjRo: What do you think?
