### PR TITLE
Fix a message deduplication race condition

### DIFF
--- a/lib/beetle/deduplication_store.rb
+++ b/lib/beetle/deduplication_store.rb
@@ -124,6 +124,12 @@ module Beetle
       with_failover { redis.setnx(key(msg_id, suffix), value) }
     end
 
+    # TODO
+    def mset(msg_id, values)
+      values = values.inject([]){|a,(k,v)| a.concat([key(msg_id, k), v])}
+      with_failover { redis.mset(*values) }
+    end
+
     # store some key/value pairs if none of the given keys exist.
     def msetnx(msg_id, values)
       values = values.inject([]){|a,(k,v)| a.concat([key(msg_id, k), v])}

--- a/lib/beetle/deduplication_store.rb
+++ b/lib/beetle/deduplication_store.rb
@@ -124,7 +124,7 @@ module Beetle
       with_failover { redis.setnx(key(msg_id, suffix), value) }
     end
 
-    # TODO
+    # store some key/value pairs
     def mset(msg_id, values)
       values = values.inject([]){|a,(k,v)| a.concat([key(msg_id, k), v])}
       with_failover { redis.mset(*values) }
@@ -144,6 +144,12 @@ module Beetle
     # retrieve the value with given <tt>suffix</tt> for given <tt>msg_id</tt>. returns a string.
     def get(msg_id, suffix)
       with_failover { redis.get(key(msg_id, suffix)) }
+    end
+
+    # retrieve the values with given <tt>suffixes</tt> for given <tt>msg_id</tt>. returns a list of strings.
+    def mget(msg_id, keys)
+      keys = keys.map{|suffix| key(msg_id, suffix)}
+      with_failover { redis.mget(*keys) }
     end
 
     # delete key with given <tt>suffix</tt> for given <tt>msg_id</tt>.

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -172,8 +172,7 @@ module Beetle
 
     # mark message handling complete in the deduplication store
     def completed!
-      @store.set(msg_id, :status, "completed")
-      timed_out!
+      @store.mset(msg_id, :status => "completed", :timeout => 0)
     end
 
     # whether we should wait before running the handler

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -236,6 +236,10 @@ module Beetle
       logger.debug "Beetle: deleted mutex: #{msg_id}"
     end
 
+    def fetch_status_delay_timeout_attempts_exceptions
+      @store.mget(msg_id, [:status, :delay, :timeout, :attempts, :exceptions])
+    end
+
     # process this message and do not allow any exception to escape to the caller
     def process(handler)
       logger.debug "Beetle: processing message #{msg_id}"
@@ -268,30 +272,33 @@ module Beetle
         run_handler(handler) == RC::HandlerCrash ? RC::AttemptsLimitReached : RC::OK
       elsif !key_exists?
         run_handler!(handler)
-      elsif completed?
-        ack!
-        RC::OK
-      elsif delayed?
-        logger.warn "Beetle: ignored delayed message (#{msg_id})!"
-        RC::Delayed
-      elsif !timed_out?
-        RC::HandlerNotYetTimedOut
-      elsif attempts_limit_reached?
-        completed!
-        ack!
-        logger.warn "Beetle: reached the handler execution attempts limit: #{attempts_limit} on #{msg_id}"
-        RC::AttemptsLimitReached
-      elsif exceptions_limit_reached?
-        completed!
-        ack!
-        logger.warn "Beetle: reached the handler exceptions limit: #{exceptions_limit} on #{msg_id}"
-        RC::ExceptionsLimitReached
       else
-        set_timeout!
-        if aquire_mutex!
-          run_handler!(handler)
+        status, delay, timeout, attempts, exceptions = fetch_status_delay_timeout_attempts_exceptions
+        if status == "completed"
+          ack!
+          RC::OK
+        elsif delay && delay.to_i > now
+          logger.warn "Beetle: ignored delayed message (#{msg_id})!"
+          RC::Delayed
+        elsif !(timeout && timeout.to_i < now)
+          RC::HandlerNotYetTimedOut
+        elsif attempts.to_i >= attempts_limit
+          completed!
+          ack!
+          logger.warn "Beetle: reached the handler execution attempts limit: #{attempts_limit} on #{msg_id}"
+          RC::AttemptsLimitReached
+        elsif exceptions.to_i > exceptions_limit
+          completed!
+          ack!
+          logger.warn "Beetle: reached the handler exceptions limit: #{exceptions_limit} on #{msg_id}"
+          RC::ExceptionsLimitReached
         else
-          RC::MutexLocked
+          set_timeout!
+          if aquire_mutex!
+            run_handler!(handler)
+          else
+            RC::MutexLocked
+          end
         end
       end
     end


### PR DESCRIPTION
Retrieve the status, delay, timeout, attempts and exceptions attributes of a message atomically as defined in the algorithm,