### PR TITLE
fixed the "message processed twice after restarts" problem

### DIFF
--- a/examples/consume_many_messages_and_shutdown_randomly.rb
+++ b/examples/consume_many_messages_and_shutdown_randomly.rb
@@ -1,0 +1,56 @@
+# consume_many_messages_and_shutdown_randomly.rb
+# this example excercises the shutdown sequence and tests whether
+# messages are handled more than once due to the shutdown
+#
+# ! check the examples/README.rdoc for information on starting your redis/rabbit !
+#
+# use it like so:
+#
+# while ruby consume_many_messages_and_shutdown_randomly.rb; do echo "no duplicate found yet"; done
+#
+# if the loop stops, a duplicate has been found.
+# you can stop this process by sending an interrupt signal
+
+trap("INT"){ puts "ignoring interrupt, please wait" }
+
+require "rubygems"
+require File.expand_path("../lib/beetle", File.dirname(__FILE__))
+
+# set Beetle log level to info, less noisy than debug
+Beetle.config.logger.level = Logger::INFO
+
+# setup client
+client = Beetle::Client.new
+client.register_queue(:test)
+client.register_message(:test)
+
+# create a redis instance with a different database
+redis = Redis.new(:db => 7)
+
+exit_code = 0
+
+# register our handler to the message, check out the message.rb for more stuff you can get from the message object
+client.register_handler(:test) do |message|
+  uuid = message.uuid
+  if redis.incr(uuid) > 1
+    exit_code = 1
+    puts "\n\nRECEIVED A MESSAGE twice: #{uuid}\n\n"
+    client.stop_listening
+  end
+end
+
+# start listening
+# this starts the event machine event loop using EM.run
+# the block passed to listen will be yielded as the last step of the setup process
+client.listen do
+  trap("TERM"){ client.stop_listening }
+  trap("INT"){ exit_code = 1; client.stop_listening }
+  # start a thread which randomly kills us
+  Thread.new do
+    sleep(2 + rand)
+    Process.kill("TERM", $$)
+  end
+  puts "trying to detect duplicates"
+end
+
+exit exit_code

--- a/examples/publish_many_messages.rb
+++ b/examples/publish_many_messages.rb
@@ -1,0 +1,23 @@
+# publish_many_messages.rb
+# this script pbulishes ARGV[0] small test messages (or 100000 if no argument is provided)
+#
+# ! check the examples/README.rdoc for information on starting your redis/rabbit !
+#
+# start it with ruby publish_many_messages.rb 1000000
+
+require "rubygems"
+require File.expand_path("../lib/beetle", File.dirname(__FILE__))
+
+# set Beetle log level to info, less noisy than debug
+Beetle.config.logger.level = Logger::INFO
+
+# setup client
+client = Beetle::Client.new
+client.register_queue(:test)
+client.register_message(:test)
+
+# publish a lot of identical messages
+n = (ARGV[0] || 100000).to_i
+n.times{ client.publish(:test, 'x') }
+
+puts "published #{n} messages"

--- a/lib/beetle/client.rb
+++ b/lib/beetle/client.rb
@@ -11,9 +11,9 @@ module Beetle
   # On the publisher side, publishing a message will ensure that the exchange it will be
   # sent to, and each of the queues bound to the exchange, will be created on demand. On
   # the subscriber side, exchanges, queues, bindings and queue subscriptions will be
-  # created when the application calls the listen method. An application can decide to
-  # subscribe to only a subset of the configured queues by passing a list of queue names
-  # to the listen method.
+  # created when the application calls the listen_queues method. An application can decide
+  # to subscribe to only a subset of the configured queues by passing a list of queue
+  # names to the listen method.
   #
   # The net effect of this strategy is that producers and consumers can be started in any
   # order, so that no message is lost if message producers are accidentally started before
@@ -216,14 +216,15 @@ module Beetle
       subscriber.listen_queues(queues, &block)
     end
 
-    # stops the eventmachine loop
+    # stops the subscriber by closing all channels and connections. note this an
+    # asynchronous operation due to the underlying eventmachine mechanism.
     def stop_listening
-      subscriber.stop!
+      @subscriber.stop! if @subscriber
     end
 
     # disconnects the publisher from all servers it's currently connected to
     def stop_publishing
-      publisher.stop
+      @publisher.stop if @publisher
     end
 
     # pause listening on a list of queues
@@ -267,8 +268,8 @@ module Beetle
     end
 
     def reset
-      stop_publishing if @publisher
-      stop_listening if @subscriber
+      stop_publishing
+      stop_listening
       config.reload
       load_brokers_from_config
     rescue Exception => e


### PR DESCRIPTION
we would probably have found this problem way earlier, if
eventmachine wouldn't silently fail when writing to a closed socket