### PR TITLE
Force stale pid file removal in redis configuration daemons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "simplecov", "~> 0.10.0"
 gem "rdoc", "~> 4.0"
 
 gem "cucumber", "~> 1.3.15"
-gem "daemons", "~> 1.1.9"
 gem "daemon_controller", "~> 1.2.0"
 gem "minitest", "~> 4.7.5"
 gem "activerecord", "~> 4.0"

--- a/beetle.gemspec
+++ b/beetle.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("amqp",                    ["= 1.0.2"])
   s.add_runtime_dependency("activesupport",           [">= 2.3.4"])
   s.add_runtime_dependency("eventmachine_httpserver", [">= 0.2.1"])
-  s.add_runtime_dependency("daemons",                 [">= 1.1.9"])
+  s.add_runtime_dependency("daemons",                 [">= 1.2.0"])
 
   s.add_development_dependency("webmock", ["~> 1.21.0"])
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,7 +37,7 @@ def redis_master_file(client_name)
 end
 
 def first_redis_configuration_client_pid
-  File.read("redis_configuration_client0.pid").chomp.to_i
+  File.read("redis_configuration_client_num0.pid").chomp.to_i
 end
 
 def system_notification_log_path

--- a/features/support/test_daemons/redis_configuration_client.rb
+++ b/features/support/test_daemons/redis_configuration_client.rb
@@ -49,7 +49,7 @@ module TestDaemons
     end
 
     def pid_file
-      "#{tmp_path}/redis_configuration_client#{@daemon_id}.pid"
+      "#{tmp_path}/redis_configuration_client_num#{@daemon_id}.pid"
     end
 
     def log_file

--- a/lib/beetle/commands/configuration_client.rb
+++ b/lib/beetle/commands/configuration_client.rb
@@ -15,7 +15,6 @@ module Beetle
     #           --config-file PATH           Path to an external yaml config file
     #           --pid-dir DIR                Write pid and log to DIR
     #           --multiple                   Allow multiple clients started in parallel (for testing only)
-    #           --force                      Force start (delete stale pid file if necessary)
     #       -v, --verbose                    Set log level to DEBUG
     #       -h, --help                       Show this message
     #
@@ -58,11 +57,6 @@ module Beetle
           multiple = true
         end
 
-        force = false
-        opts.on("--force", "Force start (delete stale pid file if necessary)") do |val|
-          force = true
-        end
-
         opts.on("-v", "--verbose", "Set log level to DEBUG") do |val|
           Beetle.config.logger.level = Logger::DEBUG
         end
@@ -79,7 +73,7 @@ module Beetle
           :log_output => true,
           :dir_mode   => dir_mode,
           :dir        => dir,
-          :force      => force
+          :force      => true
         }
 
         Daemons.run_proc("redis_configuration_client", daemon_options) do

--- a/lib/beetle/commands/configuration_server.rb
+++ b/lib/beetle/commands/configuration_server.rb
@@ -16,7 +16,6 @@ module Beetle
     #           --amqp-servers LIST          AMQP server list (e.g. 192.168.0.1:5672,192.168.0.2:5672)
     #           --config-file PATH           Path to an external yaml config file
     #           --pid-dir DIR                Write pid and log to DIR
-    #           --force                      Force start (delete stale pid file if necessary)
     #       -v, --verbose
     #       -h, --help                       Show this message
     #
@@ -61,11 +60,6 @@ module Beetle
           dir = val
         end
 
-        force = false
-        opts.on("--force", "Force start (delete stale pid file if necessary)") do |val|
-          force = true
-        end
-
         opts.on("-v", "--verbose") do |val|
           Beetle.config.logger.level = Logger::DEBUG
         end
@@ -86,7 +80,7 @@ module Beetle
           :log_output => true,
           :dir_mode   => dir_mode,
           :dir        => dir,
-          :force      => force
+          :force      => true
         }
 
         Daemons.run_proc("redis_configuration_server", daemon_options) do


### PR DESCRIPTION
Also update daemons gem dependency to handle empty pid files in conjunction with `force: true`.

@skaes: Please have a look.