### PR TITLE
Fix RabbitMQ errors when using nil or symbols as header values

### DIFF
--- a/examples/headers.rb
+++ b/examples/headers.rb
@@ -1,0 +1,42 @@
+# headers.rb
+# this example shows using custom headers
+#
+# ! check the examples/README.rdoc for information on starting your redis/rabbit !
+#
+# start it with ruby headers.rb
+
+require "rubygems"
+require File.expand_path("../lib/beetle", File.dirname(__FILE__))
+
+# set Beetle log level to info, less noisy than debug
+Beetle.config.logger.level = Logger::INFO
+
+# setup client
+client = Beetle::Client.new
+client.register_queue(:test)
+client.register_message(:test)
+
+# purge the test queue
+client.purge(:test)
+
+# empty the dedup store
+client.deduplication_store.flushdb
+
+# register our handler to the message, check out the message.rb for more stuff you can get from the message object
+client.register_handler(:test) {|message| puts "got message with headers: #{message.header.attributes[:headers]}"}
+
+# publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
+puts client.publish(:test, 'bam', :headers => {
+  :header1 => "foo",
+  :header2 => 42,
+  :header3 => 0.1,
+  :header4 => :foo, # will be converted to string
+  :header5 => nil   # will be filtered out
+})
+
+# start listening
+# this starts the event machine event loop using EM.run
+# the block passed to listen will be yielded as the last step of the setup process
+client.listen do
+  EM.add_timer(0.1) { client.stop_listening }
+end

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -97,6 +97,8 @@ module Beetle
       opts[:message_id] = generate_uuid.to_s
       opts[:timestamp] = now
       headers = (opts[:headers] ||= {})
+      headers.reject! {|k,v| v.nil? }
+      headers.each {|k,v| headers[k] = v.to_s if v.is_a?(Symbol) }
       headers.merge!(
         :format_version => FORMAT_VERSION.to_s,
         :flags => flags.to_s,

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -96,7 +96,8 @@ module Beetle
       opts = opts.slice(*PUBLISHING_KEYS)
       opts[:message_id] = generate_uuid.to_s
       opts[:timestamp] = now
-      headers = (opts[:headers] ||= {})
+      headers = {}
+      headers.merge!(opts[:headers]) if opts[:headers]
       headers.reject! {|k,v| v.nil? }
       headers.each {|k,v| headers[k] = v.to_s if v.is_a?(Symbol) }
       headers.merge!(
@@ -104,6 +105,7 @@ module Beetle
         :flags => flags.to_s,
         :expires_at => expires_at.to_s
       )
+      opts[:headers] = headers
       opts
     end
 

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -94,6 +94,16 @@ module Beetle
       assert_equal "SENDER_ID", options[:headers][:sender_id]
       assert_equal "SENDER_ACTION", options[:headers][:sender_action]
     end
+
+    test "the publishing options convert symbol values to strings" do
+      options = Message.publishing_options(:headers => { :x => :foo })
+      assert_equal "foo", options[:headers][:x]
+    end
+
+    test "the publishing options reject nil headers" do
+      options = Message.publishing_options(:headers => { :x => nil })
+      assert !options[:headers].has_key?(:x)
+    end
   end
 
   class KeyManagementTest < MiniTest::Unit::TestCase

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -104,6 +104,12 @@ module Beetle
       options = Message.publishing_options(:headers => { :x => nil })
       assert !options[:headers].has_key?(:x)
     end
+
+    test "the publishing options don't change the passed in headers" do
+      my_opts = {:headers => { :x => nil }}
+      Message.publishing_options(my_opts)
+      assert my_opts[:headers].has_key?(:x)
+    end
   end
 
   class KeyManagementTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
This PR fixes RabbitMQ errors when sending `nil` or symbols as header values.

An even better approach would be to use the proper encoding provided by the `amq-protocol` gem, that even supports a dedicated `TYPE_VOID` to encode/decode `nil` values:
https://github.com/ruby-amqp/amq-protocol/blob/91ba2397c7139edea0f41ef2d9e6854e483c5725/lib/amq/protocol/table_value_encoder.rb#L54

But that would require an update of the `bunny` dependency. Our (very old) version `~> 0.7.10` does not use the `amq-protocol` gem for encoding. 