### PR TITLE
ensure publisher closes the connection

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -7,6 +7,7 @@ module Beetle
       @exchanges_with_bound_queues = {}
       @dead_servers = {}
       @bunnies = {}
+      at_exit { stop }
     end
 
     # list of exceptions potentially raised by bunny
@@ -216,6 +217,7 @@ module Beetle
     def stop!(exception=nil)
       begin
         Beetle::Timer.timeout(1) do
+          logger.debug "Beetle: closing connection from publisher to #{server}"
           if exception
             bunny.__send__ :close_socket
           else


### PR DESCRIPTION
This will remove the `connection_closed_abruptly`
warning from rabbitmq.

I don't think there is a sensible way to cover this with unit/integration tests. I did a manual integration test already.