### PR TITLE
Use amqp protocol version 0.9 by default

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -166,7 +166,8 @@ module Beetle
         :pass           => @client.config.password,
         :vhost          => @client.config.vhost,
         :frame_max      => @client.config.frame_max,
-        :socket_timeout => @client.config.publishing_timeout)
+        :socket_timeout => @client.config.publishing_timeout,
+        :spec => '09')
       b.start
       b
     end

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -263,7 +263,7 @@ module Beetle
       header.expects(:ack)
       message = Message.new("somequeue", header, 'foo', :store => @store)
 
-      assert_equal nil, @store.get(message.msg_id, :ack_count)
+      assert_nil @store.get(message.msg_id, :ack_count)
       message.process(lambda {|*args|})
       assert message.redundant?
       assert_equal "1", @store.get(message.msg_id, :ack_count)

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -24,7 +24,8 @@ module Beetle
         :pass => "guest",
         :vhost => "/",
         :socket_timeout => 0,
-        :frame_max => 131072
+        :frame_max => 131072,
+        :spec => '09'
       }
       Bunny.expects(:new).with(expected_bunny_options).returns(m)
       m.expects(:start)


### PR DESCRIPTION
Use version 0.9 by default which allows new types for headers including the `boolean` type.