### PR TITLE
Expiration option for Message

### DIFF
--- a/examples/attempts_with_dlx_and_per_message_expiration.rb
+++ b/examples/attempts_with_dlx_and_per_message_expiration.rb
@@ -1,0 +1,66 @@
+# attempts_with_dlx_and_per_message_ttl.rb
+# ! check the examples/README.rdoc for information on starting your redis/rabbit !
+#
+# start it with `ruby attempts_with_dlx_and_per_message_ttl.rb`
+
+require "rubygems"
+require File.expand_path("../lib/beetle", File.dirname(__FILE__))
+
+# set Beetle log level to info, less noisy than debug
+Beetle.config.logger.level = Logger::INFO
+
+# setup client with dead lettering enabled
+config = Beetle::Configuration.new
+config.dead_lettering_enabled = true
+config.dead_lettering_msg_ttl = 6000
+
+client = Beetle::Client.new(config)
+client.register_queue(:test)
+client.register_message(:test)
+
+client.register_message(:test_dead_letter) # to allow for directly publishing to this queue (just proof of concept)
+
+# purge the test queue
+client.purge(:test)
+client.register_queue(:test_dead_letter) # only registered to use purge (the dead letter queues are not registered with beetle)
+client.purge(:test_dead_letter)
+# empty the dedup store
+client.deduplication_store.flushdb
+
+# setup our counter
+$completed = 0
+$expected = 3
+# store the start time
+$start_time = Time.now.to_f
+
+# declare a handler class for message processing
+class Handler < Beetle::Handler
+  def process
+    logger.info "Processed after #{Time.now.to_f - $start_time}s: #{message.data}"
+    $completed += 1
+  end
+end
+client.register_handler(:test, Handler)
+
+# publish messages directly into the queue whose dlx setup points backwards to the target queue 'test'
+client.publish(:test_dead_letter, 'earliest', expiration: 2000)                # processed after 2 seconds
+client.publish(:test_dead_letter, 'latest', expiration: 8000)                  # processed after 8 seconds
+client.publish(:test_dead_letter, 'should be in the middle', expiration: 5000) # processed after 8 seconds
+puts "published 3 test messages"
+
+# start the listening loop
+client.listen_queues([:test]) do
+  # catch INT-signal and stop listening
+  trap("INT") { client.stop_listening }
+  timer = EM.add_periodic_timer(1) do
+    if $completed == $expected
+      timer.cancel
+      client.stop_listening
+    end
+  end
+end
+
+puts "Handled #{$completed} messages"
+if $completed != $expected
+  raise "Did not handle the correct number of messages"
+end

--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -33,7 +33,7 @@ module Beetle
   # AMQP options for queue bindings
   QUEUE_BINDING_KEYS      = [:key, :no_wait]
   # AMQP options for message publishing
-  PUBLISHING_KEYS         = [:key, :mandatory, :immediate, :persistent, :reply_to, :headers, :priority]
+  PUBLISHING_KEYS         = [:key, :mandatory, :immediate, :persistent, :reply_to, :headers, :priority, :expiration]
   # AMQP options for subscribing to queues
   SUBSCRIPTION_KEYS       = [:ack, :key]
 

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -46,14 +46,17 @@ module Beetle
 
     test "the publishing options should include both the beetle headers and the amqp params" do
       key = 'fookey'
-      options = Message.publishing_options(:redundant => true, :key => key, :mandatory => true, :immediate => true, :persistent => true, :priority => 10)
+      options = Message.publishing_options(:redundant => true, :key => key, :mandatory => true,
+                                           :immediate => true, :persistent => true, :priority => 10, :expiration => 2000)
 
       assert options[:mandatory]
       assert options[:immediate]
       assert options[:persistent]
+      assert options[:expiration]
       assert_equal key, options[:key]
       assert_equal "1", options[:headers][:flags]
       assert_equal 10, options[:priority]
+      assert_equal 2000, options[:expiration]
     end
 
     test "the publishing options should silently ignore other parameters than the valid publishing keys" do
@@ -77,7 +80,7 @@ module Beetle
     end
 
     test "the publishing options must only include string values" do
-      options = Message.publishing_options(:redundant => true, :mandatory => true, :bogus => true)
+      options = Message.publishing_options(:redundant => true, :mandatory => true, :expiration => 2000, :bogus => true)
 
       assert options[:headers].all? {|_, param| param.is_a?(String)}
     end


### PR DESCRIPTION
As discussed, here is a very simple PR that just enables the client to set the `expiration` property per message as specified in the rabbitmq docs (http://www.rabbitmq.com/ttl.html#per-message-ttl-in-publishers) via beetle.

Unfortunately, it is *not* suitable for the use case  I had in mind ("publish_later/process_at" at a given time) as we can see from the example.
Messages with lower TTL that are published after messages with higher TTL are blocked until the ones with higher TTL expire.

The attempts file is intended to show the intended use case and how this fails (in delaying a later message with lower TTL until all the message before with higher TTL have expired). Hence, the PR may - if still merged - could certainly leave out the attempts file. 

As a sidenote: To achieve my intended use case I try to create another PR that works client-based in the fashion the 'delay' option works.