### PR TITLE
`retry_on` parameter to control retry mechanism

### DIFF
--- a/examples/attempts_with_dead_letter_and_exponential_backoff.rb
+++ b/examples/attempts_with_dead_letter_and_exponential_backoff.rb
@@ -36,7 +36,7 @@ class Handler < Beetle::Handler
   # called when the handler receives the message, fails on first two attempts
   # succeeds on the next and counts up our counter
   def process
-    logger.info "Attempts: #{message.attempts} for `#{message.data}`, Base Delay: #{message.delay}, Processed at: #{Time.now.to_f - $start_time}"
+    logger.info "Attempts: #{message.attempts}, Base Delay: #{message.delay}, Processed at: #{Time.now.to_f - $start_time}"
     raise "attempt #{message.attempts} for message #{message.data}" if message.attempts < $exceptions_limit
     logger.info "processing of message #{message.data} succeeded on attempt #{message.attempts}. completed: #{$completed += 1}"
   end
@@ -49,10 +49,9 @@ end
 
 # register our handler to the message, configure it to our max_attempts limit, we configure a (base) delay of 0.5
 client.register_handler(:test, Handler, exceptions: $exceptions_limit, delay: 1, max_delay: 10)
-puts "publish 2 test messages with payload `FIRST` and `SECOND`"
 # publish test messages
-client.publish(:test, "FIRST")
-client.publish(:test, "SECOND")
+client.publish(:test, 1) # publish returns the number of servers the message has been sent to
+puts "published 1 test message"
 
 # start the listening loop
 client.listen do
@@ -60,7 +59,7 @@ client.listen do
   trap("INT") { client.stop_listening }
   # we're adding a periodic timer to check whether all 10 messages have been processed without exceptions
   timer = EM.add_periodic_timer(1) do
-    if $completed == 2
+    if $completed == 1
       timer.cancel
       client.stop_listening
     end
@@ -68,6 +67,6 @@ client.listen do
 end
 
 puts "Handled #{$completed} messages"
-if $completed != 2
+if $completed != 1
   raise "Did not handle the correct number of messages"
 end

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -82,7 +82,6 @@ module Beetle
 
     # extracts various values from the AMQP header properties
     def decode #:nodoc:
-      # p header.attributes
       amqp_headers = header.attributes
       @uuid = amqp_headers[:message_id]
       @timestamp = amqp_headers[:timestamp]
@@ -222,7 +221,7 @@ module Beetle
     end
 
     def exception_accepted?
-      on_exceptions.nil? || on_exceptions.any?{ |klass| @exception.is_a? klass}
+      @exception.nil? || on_exceptions.nil? || on_exceptions.any?{ |klass| @exception.is_a? klass}
     end
 
     # have we already seen this message? if not, set the status to "incomplete" and store

--- a/lib/beetle/r_c.rb
+++ b/lib/beetle/r_c.rb
@@ -30,6 +30,7 @@ module Beetle
     rc :Ancient
     rc :AttemptsLimitReached, :failure
     rc :ExceptionsLimitReached, :failure
+    rc :ExceptionNotAccepted, :failure
     rc :Delayed, :reject
     rc :HandlerCrash, :reject
     rc :HandlerNotYetTimedOut, :reject

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -345,7 +345,7 @@ module Beetle
       assert_equal "52", @store.get(message.msg_id, :delay)
     end
 
-    test "a message should delete the mutex before resetting the timer if attempts and exception limits havn't been reached" do
+    test "a message should delete the mutex before resetting the timer if attempts and exception limits haven't been reached" do
       Message.stubs(:now).returns(9)
       header = header_with_params({})
       message = Message.new("somequeue", header, 'foo', :delay => 42, :timeout => 10.seconds, :exceptions => 1, :store => @store)
@@ -377,6 +377,23 @@ module Beetle
       assert_equal RC::ExceptionsLimitReached, message.__send__(:process_internal, proc)
     end
 
+    test "a message should not be acked if the handler crashes and the exception has been registered" do
+      header = header_with_params({})
+      RegisteredException = Class.new(StandardError)
+      message = Message.new("somequeue", header, 'foo', :timeout => 10.seconds, :exceptions => 2,
+                            :on_exceptions => [RegisteredException], :store => @store)
+      assert !message.attempts_limit_reached?
+      assert !message.exceptions_limit_reached?
+      assert !message.timed_out?
+      assert !message.simple?
+      assert message.exception_accepted? # @exception yet nil, hence 'accepted'
+
+      proc = lambda {|_| raise RegisteredException, "crash"}
+      message.expects(:completed!).never
+      header.expects(:ack).never
+      assert_equal RC::HandlerCrash, message.__send__(:process_internal, proc)
+    end
+
     test "a message should be acked if the handler crashes and the exception has not been registered" do
       header = header_with_params({})
       RegisteredException = Class.new(StandardError)
@@ -389,8 +406,7 @@ module Beetle
       assert !message.simple?
       assert message.exception_accepted? # @exception yet nil, hence 'accepted'
 
-      proc = lambda {|*args| raise OtherException, "crash"}
-      s = sequence("s")
+      proc = lambda {|_| raise OtherException, "crash"}
       message.expects(:completed!).once
       header.expects(:ack)
       assert_equal RC::ExceptionNotAccepted, message.__send__(:process_internal, proc)

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -381,7 +381,7 @@ module Beetle
       header = header_with_params({})
       RegisteredException = Class.new(StandardError)
       message = Message.new("somequeue", header, 'foo', :timeout => 10.seconds, :exceptions => 2,
-                            :on_exceptions => [RegisteredException], :store => @store)
+                            :retry_on => [RegisteredException], :store => @store)
       assert !message.attempts_limit_reached?
       assert !message.exceptions_limit_reached?
       assert !message.timed_out?
@@ -399,7 +399,7 @@ module Beetle
       RegisteredException = Class.new(StandardError)
       OtherException = Class.new(StandardError)
       message = Message.new("somequeue", header, 'foo', :timeout => 10.seconds, :exceptions => 2,
-                            :on_exceptions => [RegisteredException], :store => @store)
+                            :retry_on => [RegisteredException], :store => @store)
       assert !message.attempts_limit_reached?
       assert !message.exceptions_limit_reached?
       assert !message.timed_out?
@@ -682,8 +682,8 @@ module Beetle
         adapter:  "mysql2",
         username: "root",
         encoding: "utf8",
-        host: "127.0.0.1",
-        port: 3306
+        host: ENV['MYSQL_HOST'] || "127.0.0.1",
+        port: ENV['MYSQL_PORT'] || 3306
       )
     end
 


### PR DESCRIPTION
The beetle client allows to set an `exceptions_limit` on registering a handler e.g. like this:
```
client.register_handler(:test, Handler, exceptions: 4, delay: 1, max_delay: 10)
```
In this case the message is reenqueued (and delayed) on *all* exceptions. 

This PR just introduces another parameter `retry_on` that enables the user to specify on which exceptions (and their children) to react in this fashion:
```
client.register_handler(:test, Handler, exceptions: 4, retry_on: [MySpecialReenqueueException, Typhoeus::Error], ...)
```
