### PR TITLE
Use SecureRandom if uuid4r is not available

### DIFF
--- a/beetle.gemspec
+++ b/beetle.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   }
 
   s.specification_version = 3
-  s.add_runtime_dependency "uuid4r",                  ">= 0.1.2"
   s.add_runtime_dependency "bunny",                   "~> 0.7.12"
   s.add_runtime_dependency "redis",                   ">= 2.2.2"
   s.add_runtime_dependency "hiredis",                 ">= 0.4.5"
@@ -31,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "amqp",                    "= 1.6.0"
   s.add_runtime_dependency "activesupport",           ">= 2.3.4"
 
+  s.add_development_dependency "uuid4r",              ">= 0.1.2"
   s.add_development_dependency "activerecord",        "~> 5.0"
   s.add_development_dependency "cucumber",            "~> 2.4.0"
   s.add_development_dependency "daemon_controller",   "~> 1.2.0"

--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -1,7 +1,6 @@
 $:.unshift(File.expand_path('..', __FILE__))
 require 'bunny'                    # which bunny picks up
 require 'qrack/errors'             # needed by the publisher
-require 'uuid4r'
 require 'redis/connection/hiredis' # require *before* redis as specified in the redis-rb gem docs
 require 'redis'
 require 'active_support/all'

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -146,8 +146,15 @@ module Beetle
     end
 
     # generate uuid for publishing
-    def self.generate_uuid
-      UUID4R::uuid(4)
+    begin
+      require "uuid4r"
+      def self.generate_uuid
+        UUID4R::uuid(4)
+      end
+    rescue LoadError
+      def self.generate_uuid
+        SecureRandom.uuid
+      end
     end
 
     # whether the publisher has tried sending this message to two servers


### PR DESCRIPTION
Fixes: https://github.com/xing/beetle/issues/50

# Problem

Currently beetle uses UUID4R gem for generating message UUID.
UUID4R gem uses OSSP-UUID native library.
OSSP-UUID library is outdated (2008). It is also not included as package in many linux distributions.
Therefore many times developers are stuck installing this library by compiling from the source.

# Proposal
Replace UUID4R gem with SecureRandom.

# Speed benchmark
SecureRandom seems like a 4 times faster solution than UUID4R:

```
[4] pry(main)> Benchmark.bmbm(100) { |b| b.report('SecureRandom.uuid') { SecureRandom.uuid }; b.report('UUID4R::uuid(4)') { UUID4R::uuid(4) } }
Rehearsal ----------------------------------------------------------------------------------------------------------------------------------------
SecureRandom.uuid                                                                                      0.000037   0.000004   0.000041 (  0.000034)
UUID4R::uuid(4)                                                                                        0.000032   0.000112   0.000144 (  0.000144)
------------------------------------------------------------------------------------------------------------------------------- total: 0.000185sec

                                                                                                           user     system      total        real
SecureRandom.uuid                                                                                      0.000029   0.000003   0.000032 (  0.000027)
UUID4R::uuid(4)                                                                                        0.000030   0.000078   0.000108 (  0.000103)
```