### PR TITLE
ruby client: support lazy queues

### DIFF
--- a/examples/attempts.rb
+++ b/examples/attempts.rb
@@ -16,6 +16,7 @@ Beetle.config.logger.level = Logger::INFO
 # setup client
 $client = Beetle::Client.new
 $client.config.dead_lettering_enabled = true
+$client.config.lazy_queues_enabled = true
 $client.configure(:key => "my.test.message") do
   message(:test)
   queue(:test)

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -62,6 +62,11 @@ module Beetle
     # in bunny.
     attr_accessor :channel_max
 
+    # Lazy queues have the advantage of consuming a lot less memory on the broker. For backwards
+    # compatibility, they are disabled by default.
+    attr_accessor :lazy_queues_enabled
+    alias_method :lazy_queues_enabled?, :lazy_queues_enabled
+
     # In contrast to RabbitMQ 2.x, RabbitMQ 3.x preserves message order when requeing a message. This can lead to
     # throughput degradation (when rejected messages block the processing of other messages
     # at the head of the queue) in some cases.
@@ -137,6 +142,8 @@ module Beetle
       self.dead_lettering_enabled = false
       self.dead_lettering_msg_ttl = 1000 #1 second
       self.dead_lettering_read_timeout = 3 #3 seconds
+
+      self.lazy_queues_enabled = false
 
       self.publishing_timeout = 0
       self.tmpdir = "/tmp"

--- a/test/beetle/dead_lettering_test.rb
+++ b/test/beetle/dead_lettering_test.rb
@@ -3,18 +3,20 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 module Beetle
   class SetDeadLetteringsTest < Minitest::Test
     def setup
-      @dead_lettering = DeadLettering.new(Configuration.new)
+      @config = Configuration.new
+      @dead_lettering = DeadLettering.new(@config)
+      @config.dead_lettering_enabled = true
     end
 
     test "creates a dead letter queue for each server" do
       servers = %w(a b)
 
-      @dead_lettering.expects(:set_dead_letter_policy!).
+      @dead_lettering.expects(:set_queue_policy!).
         with("a", "QUEUE_NAME", :message_ttl => 10000)
-      @dead_lettering.expects(:set_dead_letter_policy!).
+      @dead_lettering.expects(:set_queue_policy!).
         with("b", "QUEUE_NAME", :message_ttl => 10000)
 
-      @dead_lettering.set_dead_letter_policies!(servers, "QUEUE_NAME", :message_ttl => 10000)
+      @dead_lettering.set_queue_policies!(servers, "QUEUE_NAME", :message_ttl => 10000)
     end
   end
 
@@ -25,21 +27,22 @@ module Beetle
       @config = Configuration.new
       @config.logger = Logger.new("/dev/null")
       @dead_lettering = DeadLettering.new(@config)
+      @config.dead_lettering_enabled = true
     end
 
     test "raises exception when queue name wasn't specified" do
       assert_raises ArgumentError do
-        @dead_lettering.set_dead_letter_policy!(@server, "")
+        @dead_lettering.set_queue_policy!(@server, "")
       end
     end
 
     test "raises exception when no server was specified" do
       assert_raises ArgumentError do
-        @dead_lettering.set_dead_letter_policy!("", @queue_name)
+        @dead_lettering.set_queue_policy!("", @queue_name)
       end
     end
 
-    test "creates a policy by posting to the rabbitmq" do
+    test "creates a policy by posting to the rabbitmq if dead lettering is enabled" do
       stub_request(:put, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
         .with(basic_auth: ['guest', 'guest'])
         .with(:body => {
@@ -52,7 +55,24 @@ module Beetle
                }}.to_json)
         .to_return(:status => 204)
 
-      @dead_lettering.set_dead_letter_policy!(@server, @queue_name)
+      @dead_lettering.set_queue_policy!(@server, @queue_name)
+    end
+
+    test "creates a policy by posting to the rabbitmq if lazy queues are enabled" do
+      @config.lazy_queues_enabled = true
+      @config.dead_lettering_enabled = false
+      stub_request(:put, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
+        .with(basic_auth: ['guest', 'guest'])
+        .with(:body => {
+               "pattern" => "^QUEUE_NAME$",
+               "priority" => 1,
+               "apply-to" => "queues",
+               "definition" => {
+                 "queue-mode" => "lazy"
+               }}.to_json)
+        .to_return(:status => 204)
+
+      @dead_lettering.set_queue_policy!(@server, @queue_name)
     end
 
     test "raises exception when policy couldn't successfully be created" do
@@ -61,7 +81,7 @@ module Beetle
         .to_return(:status => [405])
 
       assert_raises DeadLettering::FailedRabbitRequest do
-        @dead_lettering.set_dead_letter_policy!(@server, @queue_name)
+        @dead_lettering.set_queue_policy!(@server, @queue_name)
       end
     end
 
@@ -79,7 +99,7 @@ module Beetle
                 }}.to_json)
         .to_return(:status => 204)
 
-      @dead_lettering.set_dead_letter_policy!(@server, @queue_name, :message_ttl => 10000)
+      @dead_lettering.set_queue_policy!(@server, @queue_name, :message_ttl => 10000)
     end
 
     test "properly encodes the vhost from the configuration" do
@@ -97,7 +117,7 @@ module Beetle
 
       @config.vhost = "foo/"
 
-      @dead_lettering.set_dead_letter_policy!(@server, @queue_name)
+      @dead_lettering.set_queue_policy!(@server, @queue_name)
     end
   end
 
@@ -110,9 +130,10 @@ module Beetle
       @servers = ["localhost:55672"]
     end
 
-    test "is turned off by default" do
+    test "is does not call out to rabbit if neither dead lettering nor lazy queues are enabled" do
+      @config.dead_lettering_enabled = false
       channel = stub('channel')
-      @dead_lettering.expects(:set_dead_letter_policies!).never
+      @dead_lettering.expects(:run_rabbit_http_request).never
       @dead_lettering.bind_dead_letter_queues!(channel, @servers, @queue_name)
     end
 
@@ -122,8 +143,8 @@ module Beetle
       channel = stub('channel')
 
       channel.expects(:queue).with("#{@queue_name}_dead_letter", {})
-      @dead_lettering.expects(:set_dead_letter_policies!).with(@servers, @queue_name)
-      @dead_lettering.expects(:set_dead_letter_policies!).with(@servers, "#{@queue_name}_dead_letter",
+      @dead_lettering.expects(:set_queue_policies!).with(@servers, @queue_name)
+      @dead_lettering.expects(:set_queue_policies!).with(@servers, "#{@queue_name}_dead_letter",
         :routing_key => @queue_name,
         :message_ttl => 1000
       )


### PR DESCRIPTION
By setting lazy_queues_enabled on a beetle config, every queue gets a a lazy queue policy. Of course, this setting is orthogonal to enabling dead letter queues. 