### PR TITLE
set beetle disconnect timeout > bunny

### DIFF
--- a/beetle.gemspec
+++ b/beetle.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 3
   s.add_runtime_dependency "uuid4r",                  ">= 0.1.2"
-  s.add_runtime_dependency "bunny",                   "~> 0.7.10"
+  s.add_runtime_dependency "bunny",                   "~> 0.7.12"
   s.add_runtime_dependency "redis",                   ">= 2.2.2"
   s.add_runtime_dependency "hiredis",                 ">= 0.4.5"
   s.add_runtime_dependency "amq-protocol",            "= 2.0.1"

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -89,6 +89,11 @@ module Beetle
     # consider this a highly experimental feature for now.
     attr_accessor :publishing_timeout
 
+    # the connect/disconnect timeout in seconds for the publishing connection
+    # (defaults to <tt>5</tt>).
+    # consider this a highly experimental feature for now.
+    attr_accessor :publisher_connect_timeout
+
     # Prefetch count for subscribers (defaults to 1). Setting this higher
     # than 1 can potentially increase throughput, but comes at the cost of
     # decreased parallelism.
@@ -139,6 +144,7 @@ module Beetle
       self.dead_lettering_read_timeout = 3 #3 seconds
 
       self.publishing_timeout = 0
+      self.publisher_connect_timeout = 5
       self.tmpdir = "/tmp"
 
       self.log_file = STDOUT

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -225,7 +225,7 @@ module Beetle
 
     def stop!(exception=nil)
       return unless bunny?
-      timeout = @client.config.publisher_connect_timeout * 2 + 1
+      timeout = @client.config.publishing_timeout + @client.config.publisher_connect_timeout + 1
       Beetle::Timer.timeout(timeout) do
         logger.debug "Beetle: closing connection from publisher to #{server}"
         if exception

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -24,6 +24,7 @@ module Beetle
         :pass => "guest",
         :vhost => "/",
         :socket_timeout => 0,
+        :connect_timeout => 5,
         :frame_max => 131072,
         :channel_max => 2047,
         :spec => '09'


### PR DESCRIPTION
Bunny has a disconnect_timeout that is applied to each channel and to
the connection. This sets beetle's timeout accordingly to give bunny the time necessary
to disconnect properly (without just closing the TCP connection after 1 second).