### PR TITLE
delayed expiry of status keys in Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ rvm:
   - 2.6.2
 before_script:
   - sudo rm -rf /usr/local/go
-  - curl -s https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | sudo tar xzCf /usr/local -
+  - curl -s https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz | sudo tar xzCf /usr/local -
   - export GOROOT=/usr/local/go
   - export PATH=/usr/local/go/bin:$PATH
-  - curl -s https://releases.hashicorp.com/consul/1.4.4/consul_1.4.4_linux_amd64.zip >/tmp/consul.zip; sudo unzip -d /usr/local/bin /tmp/consul.zip; sudo chmod 755 /usr/local/bin/consul
+  - curl -s https://releases.hashicorp.com/consul/1.5.2/consul_1.5.2_linux_amd64.zip >/tmp/consul.zip; sudo unzip -d /usr/local/bin /tmp/consul.zip; sudo chmod 755 /usr/local/bin/consul
   - "consul agent -dev -node machine >/tmp/consul.log 2>&1 &"
 script: "make && make test && (bundle exec rake || (tail -n +1 tmp/*.{log,output}; false))"
 services:

--- a/Rakefile
+++ b/Rakefile
@@ -120,5 +120,6 @@ RDoc::Task.new do |rdoc|
 end
 
 task :clean do
-  system('rm -f tmp/*.output tmp/*.log tmp/master/* tmp/slave/* tmp/*lock tmp/*pid test.log')
+  sh "rm -f tmp/*.output tmp/*.log tmp/master/* tmp/slave/* tmp/*lock tmp/*pid test.log"
+  sh "find tmp -name '*.rdb' -o -name '*.aof' | xargs rm"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -121,5 +121,5 @@ end
 
 task :clean do
   sh "rm -f tmp/*.output tmp/*.log tmp/master/* tmp/slave/* tmp/*lock tmp/*pid test.log"
-  sh "find tmp -name '*.rdb' -o -name '*.aof' | xargs rm"
+  sh "find tmp -name '*.rdb' -o -name '*.aof' -print | xargs rm -f"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -120,6 +120,5 @@ RDoc::Task.new do |rdoc|
 end
 
 task :clean do
-  sh "rm -f tmp/*.output tmp/*.log tmp/master/* tmp/slave/* tmp/*lock tmp/*pid test.log"
-  sh "find tmp -name '*.rdb' -o -name '*.aof' -print | xargs rm -f"
+  sh "rm -f tmp/*.output tmp/*.log tmp/master-dir/* tmp/slave-dir/* tmp/*lock tmp/*pid test.log"
 end

--- a/features/redis_auto_failover.feature
+++ b/features/redis_auto_failover.feature
@@ -49,7 +49,7 @@ Feature: Redis auto failover
   Scenario: Successful double redis master switch with multiple failover sets
     Given a redis server "redis-3" exists as master
     And a redis server "redis-4" exists as slave of "redis-3"
-    Given a redis configuration server using redis servers "system/redis-1,redis-2;b/redis-3,redis-4" with clients "rc-client-1,rc-client-2" exists
+    Given a redis configuration server using redis servers "system/redis-1,redis-2;system2/redis-3,redis-4" with clients "rc-client-1,rc-client-2" exists
     And a redis configuration client "rc-client-1" using redis servers "redis-1,redis-2" exists
     And a redis configuration client "rc-client-2" using redis servers "redis-1,redis-2" exists
     And a beetle handler using the redis-master file from "rc-client-1" exists

--- a/features/redis_auto_failover.feature
+++ b/features/redis_auto_failover.feature
@@ -27,7 +27,7 @@ Feature: Redis auto failover
   Scenario: Successful single redis master switch with multiple failover sets
     Given a redis server "redis-3" exists as master
     And a redis server "redis-4" exists as slave of "redis-3"
-    Given a redis configuration server using redis servers "a/redis-1,redis-2;b/redis-3,redis-4" with clients "rc-client-1,rc-client-2" exists
+    Given a redis configuration server using redis servers "system/redis-1,redis-2;system2/redis-3,redis-4" with clients "rc-client-1,rc-client-2" exists
     And a redis configuration client "rc-client-1" using redis servers "redis-1,redis-2" exists
     And a redis configuration client "rc-client-2" using redis servers "redis-1,redis-2" exists
     And a beetle handler using the redis-master file from "rc-client-1" exists
@@ -37,10 +37,10 @@ Feature: Redis auto failover
     And the role of redis server "redis-2" should be "master"
     And the redis master file of the redis configuration server should contain "redis-2"
     And the redis master file of the redis configuration server should contain "redis-3"
-    And the redis master of "rc-client-1" in system "a" should be "redis-2"
-    And the redis master of "rc-client-2" in system "a" should be "redis-2"
-    And the redis master of "rc-client-1" in system "b" should be "redis-3"
-    And the redis master of "rc-client-2" in system "b" should be "redis-3"
+    And the redis master of "rc-client-1" in system "system" should be "redis-2"
+    And the redis master of "rc-client-2" in system "system" should be "redis-2"
+    And the redis master of "rc-client-1" in system "system2" should be "redis-3"
+    And the redis master of "rc-client-2" in system "system2" should be "redis-3"
     And the redis master of the beetle handler should be "redis-2"
     And a system notification for switching from "redis-1" to "redis-2" should be sent
     Given a redis server "redis-1" exists as master
@@ -49,7 +49,7 @@ Feature: Redis auto failover
   Scenario: Successful double redis master switch with multiple failover sets
     Given a redis server "redis-3" exists as master
     And a redis server "redis-4" exists as slave of "redis-3"
-    Given a redis configuration server using redis servers "a/redis-1,redis-2;b/redis-3,redis-4" with clients "rc-client-1,rc-client-2" exists
+    Given a redis configuration server using redis servers "system/redis-1,redis-2;b/redis-3,redis-4" with clients "rc-client-1,rc-client-2" exists
     And a redis configuration client "rc-client-1" using redis servers "redis-1,redis-2" exists
     And a redis configuration client "rc-client-2" using redis servers "redis-1,redis-2" exists
     And a beetle handler using the redis-master file from "rc-client-1" exists
@@ -60,10 +60,10 @@ Feature: Redis auto failover
     And the role of redis server "redis-4" should be "master"
     And the redis master file of the redis configuration server should contain "redis-2"
     And the redis master file of the redis configuration server should contain "redis-4"
-    And the redis master of "rc-client-1" in system "a" should be "redis-2"
-    And the redis master of "rc-client-2" in system "a" should be "redis-2"
-    And the redis master of "rc-client-1" in system "b" should be "redis-4"
-    And the redis master of "rc-client-2" in system "b" should be "redis-4"
+    And the redis master of "rc-client-1" in system "system" should be "redis-2"
+    And the redis master of "rc-client-2" in system "system" should be "redis-2"
+    And the redis master of "rc-client-1" in system "system2" should be "redis-4"
+    And the redis master of "rc-client-2" in system "system2" should be "redis-4"
     And the redis master of the beetle handler should be "redis-2"
     Given a redis server "redis-1" exists as master
     Then the role of redis server "redis-1" should be "slave"

--- a/features/support/beetle_handler
+++ b/features/support/beetle_handler
@@ -42,7 +42,7 @@ Daemons.run_proc("beetle_handler", :log_output => true, :dir_mode => :normal, :d
     config.handler(Beetle.config.beetle_policy_updates_queue_name) do |message|
       begin
         Beetle.config.logger.info "received beetle policy update message': #{message.data}"
-        client.set_queue_policies!(JSON.parse(message.data))
+        client.update_queue_properties!(JSON.parse(message.data))
       rescue => e
         Beetle.config.logger.error("#{e}:#{e.backtrace.join("\n")}")
       end

--- a/features/support/beetle_handler
+++ b/features/support/beetle_handler
@@ -8,16 +8,19 @@ require File.expand_path("../../lib/beetle", File.dirname(__FILE__))
 
 tmp_path = File.expand_path("../../tmp", File.dirname(__FILE__))
 
+$redis_master_file_path = ""
+
 Daemons.run_proc("beetle_handler", :log_output => true, :dir_mode => :normal, :dir => tmp_path) do
   opts = OptionParser.new
 
-  opts.on("-f", "--redis-master-file path", String) do |val|
-    Beetle.config.redis_server = val
+  opts.on("-f", "--redis-master-file PATH", String) do |val|
+    $redis_master_file_path = val
   end
 
   opts.parse!(ARGV - ["start", "--"])
 
   Beetle.config.servers = "127.0.0.1:5672" # rabbitmq
+  Beetle.config.redis_server = "127.0.0.1:6379"
 
   # set Beetle log level to info, less noisy than debug
   Beetle.config.logger.level = Logger::INFO
@@ -27,10 +30,13 @@ Daemons.run_proc("beetle_handler", :log_output => true, :dir_mode => :normal, :d
     config.message(:echo)
     config.handler(:echo) do |message|
       begin
-        client.deduplication_store.redis.server
-      rescue
-        master_file_content = File.read(Beetle.config.redis_server)
-        "no redis master: exception: #{$!.class}(#{$!}), master_file: '#{master_file_content}'"
+        master_file_content = File.read($redis_master_file_path)
+        master = client.deduplication_store.extract_redis_master(master_file_content)
+        if master != ""
+          master
+        else
+          "no redis master: master_file: '#{master_file_content}'"
+        end
       end
     end
     config.handler(Beetle.config.beetle_policy_updates_queue_name) do |message|

--- a/features/support/beetle_handler
+++ b/features/support/beetle_handler
@@ -8,19 +8,16 @@ require File.expand_path("../../lib/beetle", File.dirname(__FILE__))
 
 tmp_path = File.expand_path("../../tmp", File.dirname(__FILE__))
 
-$redis_master_file_path = ""
-
 Daemons.run_proc("beetle_handler", :log_output => true, :dir_mode => :normal, :dir => tmp_path) do
   opts = OptionParser.new
 
-  opts.on("-f", "--redis-master-file PATH", String) do |val|
-    $redis_master_file_path = val
+  opts.on("-f", "--redis-master-file path", String) do |val|
+    Beetle.config.redis_server = val
   end
 
   opts.parse!(ARGV - ["start", "--"])
 
   Beetle.config.servers = "127.0.0.1:5672" # rabbitmq
-  Beetle.config.redis_server = "127.0.0.1:6379"
 
   # set Beetle log level to info, less noisy than debug
   Beetle.config.logger.level = Logger::INFO
@@ -30,13 +27,10 @@ Daemons.run_proc("beetle_handler", :log_output => true, :dir_mode => :normal, :d
     config.message(:echo)
     config.handler(:echo) do |message|
       begin
-        master_file_content = File.read($redis_master_file_path)
-        master = client.deduplication_store.extract_redis_master(master_file_content)
-        if master != ""
-          master
-        else
-          "no redis master: master_file: '#{master_file_content}'"
-        end
+        client.deduplication_store.redis.server
+      rescue
+        master_file_content = File.read(Beetle.config.redis_server)
+        "no redis master: exception: #{$!.class}(#{$!}), master_file: '#{master_file_content}'"
       end
     end
     config.handler(Beetle.config.beetle_policy_updates_queue_name) do |message|

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -16,6 +16,8 @@ module Beetle
     # default logger (defaults to <tt>Logger.new(log_file)</tt>)
     attr_accessor :logger
     # defaults to <tt>STDOUT</tt>
+    attr_accessor :redis_logger
+    # set this to a logger instance if you want redis operations to be logged. defaults to <tt>nil</tt>.
     attr_accessor :log_file
     # number of seconds after which keys are removed from the message deduplication store (defaults to <tt>1.hour</tt>)
     attr_accessor :gc_threshold

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -35,6 +35,12 @@ module Beetle
     # handler timeout.
     attr_accessor :redis_failover_timeout
 
+    # how long we want status keys survive after we are we have seen the second message of
+    # a redundant message pair. Setting this to a high value (hours) will reduce the
+    # likelyhood of executing handler logic, but require a lerger redis instance and cause
+    # a higher database size with all associated problems. Defaults to 5 minutes.
+    attr_accessor :redis_status_key_expiry_interval
+
     # how often heartbeat messages are exchanged between failover
     # daemons. defaults to 10 seconds.
     attr_accessor :redis_failover_client_heartbeat_interval
@@ -140,6 +146,7 @@ module Beetle
       self.redis_servers = ""
       self.redis_db = 4
       self.redis_failover_timeout = 180.seconds
+      self.redis_status_key_expiry_interval = 5.minutes
       self.redis_failover_client_heartbeat_interval = 10.seconds
       self.redis_failover_client_dead_interval = 60.seconds
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -35,10 +35,13 @@ module Beetle
     # handler timeout.
     attr_accessor :redis_failover_timeout
 
-    # how long we want status keys to survive after we have seen the second message of
-    # a redundant message pair. Setting this to a high value (hours) will reduce the
-    # likelihood of executing handler logic, but can cause a higher redis database
-    # size with all associated problems. Defaults to 5 minutes.
+    # how long we want status keys to survive after we have seen the second message of a
+    # redundant message pair. Defaults to 5 minutes. Setting this to a high value (hours)
+    # will reduce the likelihood of executing handler logic more than once, but can cause
+    # a higher redis database size with all associated problems. A handler can be
+    # executed more than once if the ack to the RabbitMQ server gets lost between the consumer
+    # and the RabbitMQ instance. This happens extremely seldom in our environment, but we cannot
+    # rule it out and we also don't quite understand (yet) why it happens.
     attr_accessor :redis_status_key_expiry_interval
 
     # how often heartbeat messages are exchanged between failover

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -35,10 +35,10 @@ module Beetle
     # handler timeout.
     attr_accessor :redis_failover_timeout
 
-    # how long we want status keys survive after we are we have seen the second message of
+    # how long we want status keys to survive after we have seen the second message of
     # a redundant message pair. Setting this to a high value (hours) will reduce the
-    # likelyhood of executing handler logic, but require a lerger redis instance and cause
-    # a higher database size with all associated problems. Defaults to 5 minutes.
+    # likelihood of executing handler logic, but can cause a higher redis database
+    # size with all associated problems. Defaults to 5 minutes.
     attr_accessor :redis_status_key_expiry_interval
 
     # how often heartbeat messages are exchanged between failover

--- a/lib/beetle/deduplication_store.rb
+++ b/lib/beetle/deduplication_store.rb
@@ -59,6 +59,19 @@ module Beetle
       with_failover { redis.setnx(key(msg_id, suffix), value) }
     end
 
+    # store completion status for given <tt>msg_id</tt> if it doesn't exist yet. Returns whether the
+    # operation was successful.
+    def setnx_completed!(msg_id)
+      with_failover do
+        redis.set(
+          key(msg_id, :status),
+          "completed",
+          :nx => true,
+          :ex => @config.redis_status_key_expiry_interval,
+        )
+      end
+    end
+
     # store some key/value pairs
     def mset(msg_id, values)
       values = values.inject([]){|a,(k,v)| a.concat([key(msg_id, k), v])}

--- a/lib/beetle/deduplication_store.rb
+++ b/lib/beetle/deduplication_store.rb
@@ -134,7 +134,7 @@ module Beetle
 
     # set current redis master instance (as specified in the Beetle::Configuration)
     def redis_master_from_server_string
-      @current_master ||= Redis.from_server_string(@config.redis_server, :db => @config.redis_db)
+      @current_master ||= Redis.from_server_string(@config.redis_server, :db => @config.redis_db, :logger => @config.redis_logger)
     end
 
     # set current redis master from master file
@@ -152,7 +152,7 @@ module Beetle
     def set_current_redis_master_from_master_file
       @last_time_master_file_changed = File.mtime(@config.redis_server)
       server_string = extract_redis_master(read_master_file)
-      @current_master = !server_string.blank? ? Redis.from_server_string(server_string, :db => @config.redis_db) : nil
+      @current_master = !server_string.blank? ? Redis.from_server_string(server_string, :db => @config.redis_db, :logger => @config.redis_logger) : nil
     end
 
     # extract redis master from file content and return the server for our system

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -293,13 +293,12 @@ module Beetle
         ack!
         RC::Ancient
       elsif simple?
-        if @store.setnx_completed!(msg_id)
-          rc = run_handler(handler) == RC::HandlerCrash ? RC::AttemptsLimitReached : RC::OK
-        else
-          rc = RC::OK
-        end
         ack!
-        rc
+        if @store.setnx_completed!(msg_id)
+          run_handler(handler) == RC::HandlerCrash ? RC::AttemptsLimitReached : RC::OK
+        else
+          RC::OK
+        end
       elsif !key_exists?
         run_handler!(handler)
       else

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -313,8 +313,8 @@ module Beetle
       handler = mock("handler")
       s = sequence("s")
       handler.expects(:pre_process).with(message).in_sequence(s)
-      handler.expects(:call).in_sequence(s)
       header.expects(:ack).in_sequence(s)
+      handler.expects(:call).in_sequence(s)
       assert_equal RC::OK, message.process(handler)
     end
 
@@ -325,9 +325,9 @@ module Beetle
       handler = mock("handler")
       s = sequence("s")
       handler.expects(:pre_process).with(message).in_sequence(s)
+      header.expects(:ack).in_sequence(s)
       e = Exception.new("ohoh")
       handler.expects(:call).in_sequence(s).raises(e)
-      header.expects(:ack).in_sequence(s)
       handler.expects(:process_exception).with(e).in_sequence(s)
       handler.expects(:process_failure).with(RC::AttemptsLimitReached).in_sequence(s)
       assert_equal RC::AttemptsLimitReached, message.process(handler)

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -128,7 +128,7 @@ module Beetle
       end
     end
 
-    test "successful processing of a non redundant message should delete all keys from the database (except the staus key, which should be set to expire)" do
+    test "successful processing of a non redundant message should delete all keys from the database (except the status key, which should be set to expire)" do
       header = header_with_params({})
       header.expects(:ack)
       message = Message.new("somequeue", header, 'foo', :store => @store)
@@ -147,7 +147,7 @@ module Beetle
       end
     end
 
-    test "successful processing of a redundant message twice should delete all keys from the database (except the staus key, which should be set to expire)" do
+    test "successful processing of a redundant message twice should delete all keys from the database (except the status key, which should be set to expire)" do
       header = header_with_params({:redundant => true})
       header.expects(:ack).twice
       message = Message.new("somequeue", header, 'foo', :store => @store)

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -306,7 +306,7 @@ module Beetle
       @store.flushdb
     end
 
-    test "when processing a simple message, ack should folllow calling the handler" do
+    test "when processing a simple message, ack should follow calling the handler" do
       header = header_with_params({})
       message = Message.new("somequeue", header, 'foo', :attempts => 1, :store => @store)
 


### PR DESCRIPTION
By actually tracking handler execution in one of our applications,
we have proof that every once in a while business logic (i.e. the
process method of a message handler) gets executed more than once.

This patch is an experiment to see whether we can eliminate these
duplicates by shifting the responsibility of deleting the corresponding
status key to Redis itself (with a configurable grace period).

One possible source of duplicate handler executions is the application
crashing while the ack message for the successfully processed RabbitMQ
message is still sitting in a TCP send buffer. This complication would
be handled by the patch by tuning the grace period (in many cases).
However, to fix it in all cases we'd need to keep the status keys which
act as tombstones, for as long as a message hasn't officially expired.