### PR TITLE
Fix tests for rabbitmq from brew

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,13 +30,15 @@ namespace :rabbit do
     # on my machine, the rabbitmq user is not be allowed to access my files.
     # so we need to put the config file under /tmp
     config_file = "/tmp/beetle-testing-rabbitmq-#{node_name}"
-
     create_config_file config_file, web_port
+
+    enabled_plugins_file = "/tmp/beetle-testing-rabbitmq-enabled-plugins-#{node_name}"
+    create_enabled_plugins_file enabled_plugins_file
 
     puts "starting rabbit #{node_name} on port #{port}, web management port #{web_port}"
     puts "type ^C a RETURN to abort"
     sleep 1
-    exec "sudo #{script} #{node_name} #{port} #{config_file}"
+    exec "sudo #{script} #{node_name} #{port} #{config_file} #{enabled_plugins_file}"
   end
 
   def create_config_file(config_file, web_port)
@@ -45,6 +47,12 @@ namespace :rabbit do
       f.puts "  {rabbit, [{channel_max, 1000}]},"
       f.puts "  {rabbitmq_management, [{listener, [{port, #{web_port}}]}]}"
       f.puts "]."
+    end
+  end
+
+  def create_enabled_plugins_file(enabled_plugins_file)
+    File.open("#{enabled_plugins_file}",'w') do |f|
+      f.puts "[rabbitmq_management]."
     end
   end
 

--- a/script/start_rabbit
+++ b/script/start_rabbit
@@ -14,7 +14,7 @@ export RABBITMQ_NODENAME=$1
 # combination. See clustering on a single machine guide at <http://www.rab-
 # bitmq.com/clustering.html#single-machine> for details.
 
-# RABBITMQ_NODE_IP_ADDRESS
+export RABBITMQ_NODE_IP_ADDRESS=localhost
 # Defaults to 0.0.0.0. This can be changed if you only want to bind to one net-
 # work interface.
 
@@ -22,10 +22,6 @@ export RABBITMQ_NODE_PORT=$2
 # Defaults to 5672.
 
 export RABBITMQ_CONFIG_FILE=$3
-# RABBITMQ_CLUSTER_CONFIG_FILE
-# Defaults to /etc/rabbitmq/rabbitmq_cluster.config. If this file is present it
-# is used by the server to auto-configure a RabbitMQ cluster.  See the clustering
-# guide at <http://www.rabbitmq.com/clustering.html> for details.
 export RABBITMQ_ENABLED_PLUGINS_FILE=$4
 
 rabbitmq-server

--- a/script/start_rabbit
+++ b/script/start_rabbit
@@ -26,7 +26,9 @@ export RABBITMQ_CONFIG_FILE=$3
 # Defaults to /etc/rabbitmq/rabbitmq_cluster.config. If this file is present it
 # is used by the server to auto-configure a RabbitMQ cluster.  See the clustering
 # guide at <http://www.rabbitmq.com/clustering.html> for details.
+export RABBITMQ_ENABLED_PLUGINS_FILE=$4
 
 rabbitmq-server
 
 rm -f $RABBITMQ_CONFIG_FILE
+rm -f $RABBITMQ_ENABLED_PLUGINS_FILE


### PR DESCRIPTION
Hi @skaes, here are the fixes to allow running the tests successfully using the latest RabbitMQ from homebrew.