### PR TITLE
Add minimum go version to go.mod

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,5 +1,7 @@
 module github.com/xing/beetle
 
+go 1.12
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gobuffalo/packr v1.22.0


### PR DESCRIPTION
This was added in 1.12, and running `make` added it automatically for me:
https://golang.org/doc/go1.12#modules