### PR TITLE
Fix rake tasks for starting rabbitmq

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,11 +58,11 @@ namespace :rabbit do
 
   desc "start rabbit instance 1"
   task :start1 do
-    start "rabbit1", 5672, 15672
+    start "rabbit1@localhost", 5672, 15672
   end
   desc "start rabbit instance 2"
   task :start2 do
-    start "rabbit2", 5673, 15673
+    start "rabbit2@localhost", 5673, 15673
   end
   desc "reset rabbit instances (deletes all data!)"
   task :reset do

--- a/script/start_rabbit
+++ b/script/start_rabbit
@@ -14,7 +14,7 @@ export RABBITMQ_NODENAME=$1
 # combination. See clustering on a single machine guide at <http://www.rab-
 # bitmq.com/clustering.html#single-machine> for details.
 
-export RABBITMQ_NODE_IP_ADDRESS=localhost
+export RABBITMQ_NODE_IP_ADDRESS=127.0.0.1
 # Defaults to 0.0.0.0. This can be changed if you only want to bind to one net-
 # work interface.
 


### PR DESCRIPTION
* Using the full node name (including `@localhost`) was necessary to get it started on my mac (now using macOS Catalina and RabbitMQ 3.8.3)
* Using `127.0.0.1` instead of `localhost` for `RABBITMQ_NODE_IP_ADDRESS` does not seem to make a difference anymore, so let's use an IP address as intended by the setting