### PR TITLE
enable running required services via docker-compose

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -104,6 +104,8 @@ For tests, you'll need
 * {activerecord}[https://github.com/rails/rails/tree/master/activerecord]
 * {mysql2}[https://github.com/brianmario/mysql2/]
 
+Dependencies are managed by bundler.
+
 == Authors
 
 {Stefan Kaes}[http://github.com/skaes],
@@ -131,21 +133,47 @@ distribution.
 Don't increase the gem version in your pull requests. It will be done after merging the request,
 to allow merging of pull requests in a flexible order.
 
-== Running the tests
+== Compiling beetle and running tests
 
-Beetle ships with a cucumber feature to test the automatic redis failover
-as an integration test.
+In order to execute the unit tests, you need Ruby, a running rabbitmq server, a running
+redis-server, a running mysql server and a runnning consul server.
 
-To run it, you have to start a RabbitMQ server and a consul
-development mode.
+In addition, beetle ships with a cucumber feature to test the automatic redis failover as
+an integration test. For this you need a recent Go installation in order to compile the
+beetle go binary. Just invoke `make` in the top level directory.
 
-The top level Rakefile comes with targets to start several RabbitMQ
-instances locally.  Make sure the corresponding binaries are in your
-search path. Open two shell windows and execute the following command:
+There are two ways to start the required test dependencies: using `docker-compose` or
+starting the services manually.
+
+=== Testing with docker-compose
+
+Open a separate terminal window and run
+
+     docker-compose pull
+
+followed by
+
+     docker-compose up
+
+This will start mysql, two redis servers, two RabbitMQ instances and a single consul
+development node.
+
+Note: make sure to wait until all services are properly started.
+
+
+== Tesing with  locally installed services
+
+The top level Rakefile comes with targets to start several RabbitMQ instances locally.
+Make sure the corresponding binaries are in your search path. Open three shell windows and
+execute the following command:
 
     rake rabbit:start1
 
 and
+
+   rake redis:start:master
+
+as well as
 
    rake consul:start
 
@@ -157,9 +185,8 @@ or
 
     rake cucumber
 
-
-Note: Cucumber will automatically run after the unit test when you run rake.
-
+Note: Cucumber will automatically run after the unit tests when you run `rake` without
+arguments.
 
 
 == How to release a new gem version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+version: '2'
+
+services:
+  mysql:
+    container_name: beetle-mysql
+    image: mysql:5.7
+    ports:
+      - "6612:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+
+  rabbitmq1:
+    container_name: beetle-rabbitmq1
+    image: rabbitmq:3.8-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  rabbitmq2:
+    container_name: beetle-rabbitmq2
+    image: rabbitmq:3.8-management
+    ports:
+      - "5673:5672"
+      - "15673:15672"
+
+  consul:
+    container_name: beetle-consul
+    image: consul:1.7.2
+    ports:
+      - "8500:8500"
+    command:
+      agent -dev -node machine -client 0.0.0.0
+
+  redis-master:
+    container_name: beetle-redis-master
+    image: redis:4.0
+    ports:
+      - "6370:6379"
+    volumes:
+      - ./tmp/master-dir:/data
+
+  redis-slave:
+    container_name: beetle-redis-slave
+    image: redis:4.0
+    ports:
+      - "6380:6379"
+    command: redis-server --slaveof beetle-redis-master 6379
+    volumes:
+      - ./tmp/slave-dir:/data
+    depends_on:
+      - redis-master
+
+  # redis-1:
+  #   container_name: redis-1
+  #   image: redis:4.0
+  #   ports:
+  #     - "6381:6379"
+  #   volumes:
+  #     - ./tmp/redis-1:/data
+  #   command: redis-server --pidfile redis-1.pid --logfile redis-1.log
+
+  # redis-2:
+  #   container_name: redis-2
+  #   image: redis:4.0
+  #   ports:
+  #     - "6382:6379"
+  #   volumes:
+  #     - ./tmp/redis-2:/data
+  #   command: redis-server --pidfile redis-2.pid --logfile redis-2.log
+
+  # redis-3:
+  #   container_name: redis-3
+  #   image: redis:4.0
+  #   ports:
+  #     - "6383:6379"
+  #   volumes:
+  #     - ./tmp/redis-3:/data
+  #   command: redis-server --pidfile redis-3.pid --logfile redis-3.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,44 +35,46 @@ services:
     container_name: beetle-redis-master
     image: redis:4.0
     ports:
-      - "6370:6379"
+      - "6370:6370"
     volumes:
       - ./tmp/master-dir:/data
+    command:
+      redis-server --port 6370
 
   redis-slave:
     container_name: beetle-redis-slave
     image: redis:4.0
     ports:
-      - "6380:6379"
-    command: redis-server --slaveof beetle-redis-master 6379
+      - "6380:6380"
+    command: redis-server --port 6380 --slaveof beetle-redis-master 6370
     volumes:
       - ./tmp/slave-dir:/data
     depends_on:
       - redis-master
 
   # redis-1:
-  #   container_name: redis-1
+  #   container_name: beetle-redis-1
   #   image: redis:4.0
   #   ports:
-  #     - "6381:6379"
+  #     - "6381:6381"
   #   volumes:
   #     - ./tmp/redis-1:/data
-  #   command: redis-server --pidfile redis-1.pid --logfile redis-1.log
+  #   command: redis-server --port 6381--pidfile redis-1.pid --logfile redis-1.log
 
   # redis-2:
-  #   container_name: redis-2
+  #   container_name: beetle-redis-2
   #   image: redis:4.0
   #   ports:
-  #     - "6382:6379"
+  #     - "6382:6382"
   #   volumes:
   #     - ./tmp/redis-2:/data
-  #   command: redis-server --pidfile redis-2.pid --logfile redis-2.log
+  #   command: redis-server --port 6382 --pidfile redis-2.pid --logfile redis-2.log
 
   # redis-3:
-  #   container_name: redis-3
+  #   container_name: beetle-redis-3
   #   image: redis:4.0
   #   ports:
-  #     - "6383:6379"
+  #     - "6383:6383"
   #   volumes:
   #     - ./tmp/redis-3:/data
-  #   command: redis-server --pidfile redis-3.pid --logfile redis-3.log
+  #   command: redis-server --port 6383 --pidfile redis-3.pid --logfile redis-3.log

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,9 +27,13 @@ end
 I18n.enforce_available_locales = false
 
 Beetle.config.logger = Logger.new(File.dirname(__FILE__) + '/../test.log')
-Beetle.config.redis_server = "localhost:6379"
-Beetle.config.redis_servers = "localhost:6379,localhost:6380"
-
+if `docker inspect beetle-redis-master -f '{{.State.Status}}'`.chomp == "running"
+  Beetle.config.redis_server = "localhost:6370"
+  Beetle.config.redis_servers = "localhost:6370,localhost:6380"
+else
+  Beetle.config.redis_server = "localhost:6379"
+  Beetle.config.redis_servers = "localhost:6379,localhost:6380"
+end
 
 def header_with_params(opts = {})
   beetle_headers = Beetle::Message.publishing_options(opts)
@@ -45,4 +49,8 @@ def redis_stub(name, opts = {})
   default_host = opts['host'] || "foo"
   opts = {'host' => default_host, 'port' => default_port, 'server' => "#{default_host}:#{default_port}"}.update(opts)
   stub(name, opts)
+end
+
+if `docker inspect beetle-mysql -f '{{.State.Status}}'`.chomp == "running"
+  ENV['MYSQL_PORT'] = '6612'
 end


### PR DESCRIPTION
You will still need Ruby, Go, make, Redis, etc. on your development machine.
Using docker-compose to run the Redis servers for the cucumber tests is
not easily achievable, because it would require a docker host network.
Unfortunately this does not work on a Mac.