### PR TITLE
Allow synchronous queue policy creation

### DIFF
--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -97,9 +97,12 @@ module Beetle
     attr_accessor :dead_lettering_enabled
     alias_method :dead_lettering_enabled?, :dead_lettering_enabled
 
-    # the time a message spends in the dead letter queue if dead lettering is enabled, before it is returned
+    # The time a message spends in the dead letter queue if dead lettering is enabled, before it is returned
     # to the original queue
     attr_accessor :dead_lettering_msg_ttl
+
+    # Whether to update quueue policies synchronously or asynchronously.
+    attr_accessor :update_queue_properties_synchronously
 
     # Read timeout for http requests to create dead letter bindings
     attr_accessor :rabbitmq_api_read_timeout
@@ -174,6 +177,8 @@ module Beetle
 
       self.lazy_queues_enabled = false
       self.throttling_refresh_interval = 60 # seconds
+
+      self.update_queue_properties_synchronously = false
 
       self.publishing_timeout = 0
       self.publisher_connect_timeout = 5   # seconds

--- a/test/beetle/base_test.rb
+++ b/test/beetle/base_test.rb
@@ -104,5 +104,13 @@ module Beetle
       @bs.__send__(:publish_policy_options, options)
     end
 
+    test "publish_policy_options calls the RabbitMQ API if asked to do so" do
+      options = { :lazy => true, :dead_lettering => true }
+      @bs.logger.stubs(:debug)
+      @client.config.expects(:update_queue_properties_synchronously).returns(true)
+      @client.expects(:update_queue_properties!).with(options.merge(:server => "localhost:5672"))
+      @bs.__send__(:publish_policy_options, options)
+    end
+
   end
 end


### PR DESCRIPTION
It some environments, running a queue policy manager application might be costly and performance is not important. In these cases, set `client.config.update_queue_properties_synchronously`to true.