### PR TITLE
make sure not to subscribe to any server twice

### DIFF
--- a/lib/beetle/client.rb
+++ b/lib/beetle/client.rb
@@ -385,8 +385,8 @@ module Beetle
     end
 
     def load_brokers_from_config
-      @servers = config.servers.split(/ *, */)
-      @additional_subscription_servers = config.additional_subscription_servers.split(/ *, */)
+      @servers = config.servers.split(/ *, */).uniq
+      @additional_subscription_servers = config.additional_subscription_servers.split(/ *, */).uniq - @servers
     end
   end
 end

--- a/test/beetle/client_test.rb
+++ b/test/beetle/client_test.rb
@@ -343,17 +343,17 @@ module Beetle
 
     test "trying to listen to an unknown queue should raise an exception" do
       client = Client.new
-      assert_raises(UnknownQueue) { Client.new.listen_queues([:foobar])}
+      assert_raises(UnknownQueue) { client.listen_queues([:foobar])}
     end
 
     test "trying to pause listening on an unknown queue should raise an exception" do
       client = Client.new
-      assert_raises(UnknownQueue) { Client.new.pause_listening(:foobar)}
+      assert_raises(UnknownQueue) { client.pause_listening(:foobar)}
     end
 
     test "trying to resume listening on an unknown queue should raise an exception" do
       client = Client.new
-      assert_raises(UnknownQueue) { Client.new.pause_listening(:foobar)}
+      assert_raises(UnknownQueue) { client.pause_listening(:foobar)}
     end
 
     test "should delegate stop_listening to the subscriber instance" do
@@ -457,4 +457,22 @@ module Beetle
       msg_stub
     end
   end
+
+  class ServerDeduplicationTest < Minitest::Test
+    def setup
+      @config = Configuration.new
+      @config.servers = "localhost:5672,localhost:5672"
+      @config.additional_subscription_servers = @config.servers + ",localhost:1234,localhost:1234"
+      @client = Client.new(@config)
+    end
+
+    test "duplicates are removed from the server list" do
+      assert_equal ["localhost:5672"], @client.servers
+    end
+
+    test "duplicates and servers in the server list are rmeoved from the addtional subscription server list" do
+      assert_equal ["localhost:1234"], @client.additional_subscription_servers
+    end
+  end
+
 end

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -127,7 +127,7 @@ module Beetle
       @sub = @client.send(:subscriber)
     end
 
-    test "subscribers server list should contain addtional subcription hosts" do
+    test "subscribers server list should contain additional subcription hosts" do
       assert_equal ["localhost:5672", "localhost:1234"], @sub.servers
     end
   end


### PR DESCRIPTION
This is achieved by removing duplicates from all server lists (normal and additional subscription servers) and by subtracting the normal servers from the additional ones.