### PR TITLE
ruby beetle client: remove blank entries from server list strings

### DIFF
--- a/lib/beetle/client.rb
+++ b/lib/beetle/client.rb
@@ -385,8 +385,12 @@ module Beetle
     end
 
     def load_brokers_from_config
-      @servers = config.servers.split(/ *, */).uniq
-      @additional_subscription_servers = config.additional_subscription_servers.split(/ *, */).uniq - @servers
+      @servers = parse_server_list(config.servers)
+      @additional_subscription_servers = parse_server_list(config.additional_subscription_servers) - @servers
+    end
+
+    def parse_server_list(s)
+      s.split(/ *, */).uniq.reject(&:blank?)
     end
   end
 end

--- a/test/beetle/client_test.rb
+++ b/test/beetle/client_test.rb
@@ -470,7 +470,24 @@ module Beetle
       assert_equal ["localhost:5672"], @client.servers
     end
 
-    test "duplicates and servers in the server list are rmeoved from the addtional subscription server list" do
+    test "duplicates and servers in the server list are removed from the additional subscription server list" do
+      assert_equal ["localhost:1234"], @client.additional_subscription_servers
+    end
+  end
+
+  class EmptyServerStringTest < Minitest::Test
+    def setup
+      @config = Configuration.new
+      @config.servers = "localhost:5672,\t,localhost:5672, "
+      @config.additional_subscription_servers = @config.servers + ",localhost:1234, , ,,"
+      @client = Client.new(@config)
+    end
+
+    test "empty strings are removed from the server list" do
+      assert_equal ["localhost:5672"], @client.servers
+    end
+
+    test "empty strings are rmeoved from the additional subscription server list" do
       assert_equal ["localhost:1234"], @client.additional_subscription_servers
     end
   end

--- a/test/beetle/client_test.rb
+++ b/test/beetle/client_test.rb
@@ -487,7 +487,7 @@ module Beetle
       assert_equal ["localhost:5672"], @client.servers
     end
 
-    test "empty strings are rmeoved from the additional subscription server list" do
+    test "empty strings are removed from the additional subscription server list" do
       assert_equal ["localhost:1234"], @client.additional_subscription_servers
     end
   end


### PR DESCRIPTION
Sad to say: it has happened in the past.