### PR TITLE
Parameterise server names for test setup 

### DIFF
--- a/examples/redundant.rb
+++ b/examples/redundant.rb
@@ -17,7 +17,7 @@ Beetle.config.logger.level = Logger::INFO
 client = Beetle::Client.new
 
 # use two servers
-Beetle.config.servers = "localhost:5672, localhost:5673"
+Beetle.config.servers = ENV["RABBITMQ_SERVERS"] || "localhost:5672, localhost:5673"
 # instantiate a client
 client = Beetle::Client.new
 

--- a/examples/rpc.rb
+++ b/examples/rpc.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.dirname(__FILE__)+"/../lib/beetle")
 
 # suppress debug messages
 Beetle.config.logger.level = Logger::INFO
-Beetle.config.servers = "localhost:5672, localhost:5673"
+Beetle.config.servers = ENV["RABBITMQ_SERVERS"] || "localhost:5672, localhost:5673"
 # instantiate a client
 
 client = Beetle::Client.new

--- a/features/step_definitions/redis_auto_failover_steps.rb
+++ b/features/step_definitions/redis_auto_failover_steps.rb
@@ -1,8 +1,9 @@
 Given /^consul state has been cleared$/ do
+  consul_host = ENV["CONSUL_HOST"] || "localhost:8500"
   system "killall beetle beetle_handler >/dev/null 2>/dev/null"
-  system "curl --silent --request PUT http://localhost:8500/v1/kv/apps/beetle/config/ >/dev/null"
-  system "curl --silent --request PUT http://localhost:8500/v1/kv/shared/config/ >/dev/null"
-  system "curl --silent --request DELETE http://localhost:8500/v1/kv/apps/beetle/state/redis_master_file_content >/dev/null"
+  system "curl --silent --request PUT http://#{consul_host}/v1/kv/apps/beetle/config/ >/dev/null"
+  system "curl --silent --request PUT http://#{consul_host}/v1/kv/shared/config/ >/dev/null"
+  system "curl --silent --request DELETE http://#{consul_host}/v1/kv/apps/beetle/state/redis_master_file_content >/dev/null"
 end
 
 Given /^a redis server "([^\"]*)" exists as master$/ do |redis_name|

--- a/features/support/test_daemons/redis_configuration_server.rb
+++ b/features/support/test_daemons/redis_configuration_server.rb
@@ -25,9 +25,10 @@ module TestDaemons
 
     def self.daemon_controller
       clients_parameter_string = @@redis_configuration_clients.blank? ? "" : "--client-ids #{@@redis_configuration_clients}"
+      consul_host = ENV["CONSUL_HOST"] || "localhost:8500"
       DaemonController.new(
          :identifier    => "Redis configuration test server",
-         :start_command => "./beetle configuration_server -v -d --redis-master-file #{redis_master_file} --redis-servers '#{@@redis_servers}' #{clients_parameter_string} --redis-master-retry-interval 1 --pid-file #{pid_file} --log-file #{log_file} --redis-failover-confidence-level #{@@confidence_level} --consul http://localhost:8500",
+         :start_command => "./beetle configuration_server -v -d --redis-master-file #{redis_master_file} --redis-servers '#{@@redis_servers}' #{clients_parameter_string} --redis-master-retry-interval 1 --pid-file #{pid_file} --log-file #{log_file} --redis-failover-confidence-level #{@@confidence_level} --consul http://#{consul_host}",
          :ping_command  => lambda{ answers_text_requests? },
          :pid_file      => pid_file,
          :log_file      => log_file,

--- a/test/beetle/amqp_gem_behavior_test.rb
+++ b/test/beetle/amqp_gem_behavior_test.rb
@@ -7,7 +7,7 @@ class AMQPGemBehaviorTest < Minitest::Test
     begin
       exception = nil
       EM.run do
-        AMQP.start(:logging => false) do |connection|
+        AMQP.start(logging: false, host: ENV['RABBITMQ_SERVERS'] || 'localhost') do |connection|
           EM::Timer.new(1){ connection.close { EM.stop }}
           channel = AMQP::Channel.new(connection)
           channel.on_error { puts "woot"}

--- a/test/beetle/base_test.rb
+++ b/test/beetle/base_test.rb
@@ -26,7 +26,7 @@ module Beetle
     end
 
     test "server should be initialized" do
-      assert_equal @bs.servers.first, @bs.server
+      assert @bs.server
     end
 
     test "current_host should return the hostname of the current server" do

--- a/test/beetle/client_test.rb
+++ b/test/beetle/client_test.rb
@@ -8,7 +8,7 @@ module Beetle
     end
 
     test "should have a default server" do
-      assert_equal ["localhost:5672"], @client.servers
+      assert !@client.servers.empty?
     end
 
     test "should have no additional subscription servers" do

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -77,7 +77,9 @@ module Beetle
 
   class PublisherPublishingTest < Minitest::Test
     def setup
-      @client = Client.new
+      @config = Configuration.new
+      @config.servers = ENV['RABBITMQ_SERVERS'].split(',').first if ENV['RABBITMQ_SERVERS']
+      @client = Client.new(@config)
       @pub = Publisher.new(@client)
       @pub.stubs(:bind_queues_for_exchange)
       @client.register_queue("mama", :exchange => "mama-exchange")
@@ -277,6 +279,7 @@ module Beetle
   class PublisherQueueManagementTest < Minitest::Test
     def setup
       @config = Configuration.new
+      @config.servers = ENV['RABBITMQ_SERVERS'] if ENV['RABBITMQ_SERVERS']
       @client = Client.new(@config)
       @pub = Publisher.new(@client)
     end
@@ -322,6 +325,7 @@ module Beetle
     end
 
     test "should declare queues only once even with many bindings" do
+
       @client.register_queue('test_queue', :exchange => 'test_exchange')
       @client.register_binding('test_queue', :exchange => 'test_exchange', :key => 'sir-message-a-lot')
       queue = mock("queue")
@@ -549,10 +553,11 @@ module Beetle
     end
   end
 
-
   class RPCTest < Minitest::Test
     def setup
-      @client = Client.new
+      @config = Configuration.new
+      @config.servers = ENV['RABBITMQ_SERVERS'].split(',').first if ENV['RABBITMQ_SERVERS']
+      @client = Client.new(@config)
       @pub = Publisher.new(@client)
       @client.register_message(:test, :exchange => :some_exchange)
     end

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -52,7 +52,9 @@ module Beetle
 
   class SubscriberPauseAndResumeTest < Minitest::Test
     def setup
-      @client = Client.new
+      @config = Configuration.new
+      @config.servers = "localhost:5672"
+      @client = Client.new(@config)
       @sub = @client.send(:subscriber)
       @sub.servers << "localhost:7777"
       @server1, @server2 = @sub.servers
@@ -342,7 +344,9 @@ module Beetle
 
   class SubscriptionTest < Minitest::Test
     def setup
-      @client = Client.new
+      @config = Configuration.new
+      @config.servers = "locahost:5672"
+      @client = Client.new(@config)
       @sub = @client.send(:subscriber)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,12 +27,14 @@ end
 I18n.enforce_available_locales = false
 
 Beetle.config.logger = Logger.new(File.dirname(__FILE__) + '/../test.log')
-if `docker inspect beetle-redis-master -f '{{.State.Status}}'`.chomp == "running"
-  Beetle.config.redis_server = "localhost:6370"
-  Beetle.config.redis_servers = "localhost:6370,localhost:6380"
+Beetle.config.servers = ENV["RABBITMQ_SERVERS"] || "localhost:5672"
+
+if system('docker') && `docker inspect beetle-redis-master -f '{{.State.Status}}'`.chomp == "running"
+  Beetle.config.redis_server = ENV["REDIS_SERVER"] || "localhost:6370"
+  Beetle.config.redis_servers = ENV["REDIS_SERVERS"] || "localhost:6370,localhost:6380"
 else
-  Beetle.config.redis_server = "localhost:6379"
-  Beetle.config.redis_servers = "localhost:6379,localhost:6380"
+  Beetle.config.redis_server = ENV["REDIS_SERVER"] || "localhost:6379"
+  Beetle.config.redis_servers = ENV["REDIS_SERVERS"] || "localhost:6379,localhost:6380"
 end
 
 def header_with_params(opts = {})
@@ -43,7 +45,6 @@ def header_with_params(opts = {})
   header
 end
 
-
 def redis_stub(name, opts = {})
   default_port = opts['port'] || "1234"
   default_host = opts['host'] || "foo"
@@ -51,6 +52,6 @@ def redis_stub(name, opts = {})
   stub(name, opts)
 end
 
-if `docker inspect beetle-mysql -f '{{.State.Status}}'`.chomp == "running"
+if system('docker') && `docker inspect beetle-mysql -f '{{.State.Status}}'`.chomp == "running"
   ENV['MYSQL_PORT'] = '6612'
 end


### PR DESCRIPTION
Most tests rely on having the different services (mysql, rabbitmq, consul, redis) bridged to localhost in a hardcoded way.

This PR uses environment variables for most parts in the simple for of  `ENV[..] || localhost` instead of `locahost` where possible.

The tests do not rely on reading in a Beetle.config file either, so that would have been another way to make this work. But with much more changes. This PR does not change anything when the respective ENV variables (REDIS_SERVER, RABBITMQ_SERVERS, CONSUL_HOST, MYSQL_HOST) are not present.