### PR TITLE
fixed that message publishing with headers crashes under ruby 3.2

### DIFF
--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -1,6 +1,12 @@
 $:.unshift(File.expand_path('..', __FILE__))
 require 'bunny'                    # which bunny picks up
 require 'qrack/errors'             # needed by the publisher
+
+if Gem::Version.new(Bunny::VERSION) <= Gem::Version.new("0.7.12") && !defined?(::Fixnum)
+  require 'qrack/transport/buffer09'
+  Qrack::Transport09::Buffer.class_eval "Fixnum = Integer"
+end
+
 begin
   require 'redis/connection/hiredis' # require *before* redis as specified in the redis-rb gem docs
   require 'redis'

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -1,0 +1,32 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+class BunnyBehaviorTest < Minitest::Test
+  test "publishing fixnums and hashes works in amqp headers" do
+    client = Beetle::Client.new
+    client.register_queue(:test)
+    client.register_message(:test)
+
+    # purge the test queue
+    client.purge(:test)
+
+    # empty the dedup store
+    client.deduplication_store.flushdb
+
+    # register our handler to the message, check out the message.rb for more stuff you can get from the message object
+    message = nil
+    client.register_handler(:test) {|msg| message = msg; client.stop_listening }
+
+    # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
+    published = client.publish(:test, 'bam', headers: { foo: 1, table: {bar: "baz"}})
+
+    # start listening
+    client.listen
+    client.stop_publishing
+
+    assert_equal 1, published
+    assert_equal "bam", message.data
+    headers = message.header.attributes[:headers]
+    assert_equal 1, headers["foo"]
+    assert_equal({"bar" => "baz"}, headers["table"])
+  end
+end


### PR DESCRIPTION
The crashes are caused by Fixnum no longer being available in Ruby 3.2. We have already created a PR for the old bunny, but it is unclear whether it will be merged, so we quick fix it by defining Fixnum = Integer in the only class that needs it.