### PR TITLE
Make use of CPU architecture agnoistic dup function

### DIFF
--- a/go/beetle.go
+++ b/go/beetle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/xing/beetle/consul"
 	"github.com/xing/beetle/daemonize"
+	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v2"
 )
 
@@ -276,8 +277,8 @@ func redirectStdoutAndStderr(path string) {
 		fmt.Printf("could not open log file: %s\n", err)
 		return
 	}
-	syscall.Dup2(int(logFile.Fd()), 1)
-	syscall.Dup2(int(logFile.Fd()), 2)
+	unix.Dup2(int(logFile.Fd()), 1)
+	unix.Dup2(int(logFile.Fd()), 2)
 }
 
 func getProgramParameters() *Config {

--- a/go/beetle.go
+++ b/go/beetle.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	// "github.com/davecgh/go-spew/spew"
@@ -236,7 +235,7 @@ var interrupted bool
 
 func installSignalHandler() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(c, os.Interrupt, unix.SIGTERM)
 	go func() {
 		<-c
 		logInfo("received TERM signal")


### PR DESCRIPTION
Apparently, `syscall.Dup2` does not exist on ARM systems, and `syscall.Dup3` does not exist on darwin (OSX). `unix.Dup2` provides a more portable implementation, achieving the same.

> The [syscall](https://go.dev/pkg/syscall/) package is now frozen except for changes needed to maintain the core repository. In particular, it will no longer be extended to support new or different system calls that are not used by the core. The reasons are described at length in [a separate document](https://go.dev/s/go1.4-syscall).
>
> A new subrepository, [golang.org/x/sys](https://golang.org/x/sys), has been created to serve as the location for new developments to support system calls on all kernels. [...]

via https://go.dev/doc/go1.4#major_library_changes