### PR TITLE
Allow to set connection options on a per server basis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v4.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v4.x ]
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: sudo apt-get install redis
 
       - name: Start required services
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Install gems
         run: bundle install && bundle exec appraisal install
@@ -53,5 +53,5 @@ jobs:
           BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}.gemfile
 
       - name: Stop services
-        run: docker-compose down
+        run: docker compose down
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ gemfiles/*
 /master-client.txt
 /master-server.txt
 /redis-master-rcc
+/gems
+/bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "hiredis-client"
+gem "pry"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
 
 # Use patched appraisal gem until it is fixed upstream.

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem "hiredis-client"
-
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
 
 # Use patched appraisal gem until it is fixed upstream.

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem "hiredis-client"
-gem "pry"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
 
 # Use patched appraisal gem until it is fixed upstream.

--- a/lib/beetle/base.rb
+++ b/lib/beetle/base.rb
@@ -24,11 +24,25 @@ module Beetle
     end
 
     def current_host
-      @server.split(':').first
+      host_and_port(@server).first
     end
 
     def current_port
-      @server =~ /:(\d+)$/ ? $1.to_i : 5672
+      host_and_port(@server).last
+    end
+
+    def host_and_port(server)
+      host, port = server.split(':')
+      port ||= 5672
+
+      [host, port.to_i]
+    end
+
+    def connection_options_for_server(server)
+      host, port = host_and_port(server)
+      default_opts = { host: host, port: port, user: @client.config.user, pass: @client.config.password, vhost: @client.config.vhost }
+
+      @client.config.server_connection_options.fetch(server, default_opts)
     end
 
     def set_current_server(s)

--- a/lib/beetle/base.rb
+++ b/lib/beetle/base.rb
@@ -24,25 +24,16 @@ module Beetle
     end
 
     def current_host
-      host_and_port(@server).first
+      @server.split(':').first
     end
 
     def current_port
-      host_and_port(@server).last
+      @server =~ /:(\d+)$/ ? $1.to_i : 5672
     end
 
-    def host_and_port(server)
-      host, port = server.split(':')
-      port ||= 5672
-
-      [host, port.to_i]
-    end
 
     def connection_options_for_server(server)
-      host, port = host_and_port(server)
-      default_opts = { host: host, port: port, user: @client.config.user, pass: @client.config.password, vhost: @client.config.vhost }
-
-      @client.config.server_connection_options.fetch(server, default_opts)
+      @client.config.connection_options_for_server(server)
     end
 
     def set_current_server(s)

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -182,7 +182,7 @@ module Beetle
       self.redis_configuration_client_ids = ""
 
       self.servers = "localhost:5672"
-      self.server_connection_options = { }
+      self.server_connection_options = {}
       self.additional_subscription_servers = ""
       self.vhost = "/"
       self.user = "guest"

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -244,15 +244,18 @@ module Beetle
     end
 
     def connection_options_for_server(server)
-      host, port = server.split(':')
-      port ||= 5672
-
-      default_opts = { host: host, port: port.to_i, user: user, pass: password, vhost: vhost }
-
-      server_connection_options.fetch(server, default_opts)
+      default_server_connection_options(server).merge(server_connection_options[server] || {})
     end
 
     private
+
+    def default_server_connection_options(server)
+      host, port = server.split(':')
+      port ||= 5672
+
+      { host: host, port: port.to_i, user: user, pass: password, vhost: vhost }
+    end
+
     def load_config
       raw = ERB.new(IO.read(config_file)).result
       hash = if config_file =~ /\.json$/

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -243,7 +243,9 @@ module Beetle
     # If no server specific options are set, it constructs defaults which
     # use the global user, password and vhost settings.
     def connection_options_for_server(server)
-      default_server_connection_options(server).merge(server_connection_options[server] || {})
+      overrides = server_connection_options[server] || {}
+
+      default_server_connection_options(server).merge(overrides)
     end
 
     private
@@ -257,7 +259,7 @@ module Beetle
         port: port.to_i,
         user: user,
         pass: password,
-        vhost: vhost
+        vhost: vhost,
       }
     end
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -243,6 +243,15 @@ module Beetle
       }
     end
 
+    def connection_options_for_server(server)
+      host, port = server.split(':')
+      port ||= 5672
+
+      default_opts = { host: host, port: port.to_i, user: user, pass: password, vhost: vhost }
+
+      server_connection_options.fetch(server, default_opts)
+    end
+
     private
     def load_config
       raw = ERB.new(IO.read(config_file)).result

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -259,7 +259,7 @@ module Beetle
         user: user,
         pass: password,
         vhost: vhost,
-        api_base_url: "http://#{host}:#{api_port}/api"
+        api_port: 15672,
       }
     end
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -253,7 +253,14 @@ module Beetle
       host, port = server.split(':')
       port ||= 5672
 
-      { host: host, port: port.to_i, user: user, pass: password, vhost: vhost }
+      {
+        host: host,
+        port: port.to_i,
+        user: user,
+        pass: password,
+        vhost: vhost,
+        api_port: "1#{port}".to_i
+      }
     end
 
     def load_config

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -73,8 +73,13 @@ module Beetle
 
     # list of amqp servers to use (defaults to <tt>"localhost:5672"</tt>)
     attr_accessor :servers
+
     # list of additional amqp servers to use for subscribers (defaults to <tt>""</tt>)
     attr_accessor :additional_subscription_servers
+
+    # a hash mapping a server name to a hash of connection options for that server or additional subscription server
+    attr_accessor :server_connection_options
+
     # the virtual host to use on the AMQP servers (defaults to <tt>"/"</tt>)
     attr_accessor :vhost
     # the AMQP user to use when connecting to the AMQP servers (defaults to <tt>"guest"</tt>)
@@ -177,6 +182,7 @@ module Beetle
       self.redis_configuration_client_ids = ""
 
       self.servers = "localhost:5672"
+      self.server_connection_options = { }
       self.additional_subscription_servers = ""
       self.vhost = "/"
       self.user = "guest"

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -259,7 +259,7 @@ module Beetle
         user: user,
         pass: password,
         vhost: vhost,
-        api_port: "1#{port}".to_i
+        api_base_url: "http://#{host}:#{api_port}/api"
       }
     end
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -239,6 +239,9 @@ module Beetle
       }
     end
 
+    # Returns a hash of connection options for the given server.
+    # If no server specific options are set, it constructs defaults which
+    # use the global user, password and vhost settings.
     def connection_options_for_server(server)
       default_server_connection_options(server).merge(server_connection_options[server] || {})
     end

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -123,9 +123,6 @@ module Beetle
     # Write timeout for http requests to RabbitMQ HTTP API
     attr_accessor :rabbitmq_api_write_timeout
 
-    # Returns the port on which the Rabbit API is hosted
-    attr_accessor :api_port
-
     # the socket timeout in seconds for message publishing (defaults to <tt>0</tt>).
     # consider this a highly experimental feature for now.
     attr_accessor :publishing_timeout
@@ -187,7 +184,6 @@ module Beetle
       self.vhost = "/"
       self.user = "guest"
       self.password = "guest"
-      self.api_port = 15672
       self.frame_max = 131072
       self.channel_max = 2047
       self.prefetch_count = 1
@@ -258,8 +254,7 @@ module Beetle
         port: port.to_i,
         user: user,
         pass: password,
-        vhost: vhost,
-        api_port: 15672,
+        vhost: vhost
       }
     end
 

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -161,18 +161,21 @@ module Beetle
     end
 
     def new_bunny
+      options = connection_options_for_server(@server)
+
       b = Bunny.new(
-        :host               => current_host,
-        :port               => current_port,
-        :logging            => !!@options[:logging],
-        :user               => @client.config.user,
-        :pass               => @client.config.password,
-        :vhost              => @client.config.vhost,
+        :host               => options[:host],
+        :port               => options[:port],
+        :user               => options[:user],
+        :pass               => options[:pass],
+        :vhost              => options[:vhost],
+        :ssl                => options[:ssl],
         :frame_max          => @client.config.frame_max,
         :channel_max        => @client.config.channel_max,
         :socket_timeout     => @client.config.publishing_timeout,
         :connect_timeout    => @client.config.publisher_connect_timeout,
-        :spec => '09')
+        :spec               => '09',
+        :logging            => !!@options[:logging])
       b.start
       b
     end

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -159,8 +159,6 @@ module Beetle
       connection_options = config.connection_options_for_server(server)
       api_port           = "1#{connection_options[:port]}".to_i
 
-      require 'pry'
-      binding.pry if uri.hostname == "other.example.com"
       request.basic_auth(connection_options[:user], connection_options[:pass])
       case request.class::METHOD
       when 'GET'

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -155,14 +155,18 @@ module Beetle
     end
 
     def run_rabbit_http_request(uri, request, &block)
-      request.basic_auth(config.user, config.password)
+      # TODO: is this good enough or should we pass in the server explicitly
+      server = uri.port ? "#{uri.hostname}:#{uri.port}" : uri.hostname
+      connection_options = config.connection_options_for_server(server)
+
+      request.basic_auth(connection_options.user, connection_options.pass)
       case request.class::METHOD
       when 'GET'
         request["Accept"] = "application/json"
       when 'PUT'
         request["Content-Type"] = "application/json"
       end
-      http = Net::HTTP.new(uri.hostname, config.api_port)
+      http = Net::HTTP.new(connection_options.host, connection_options.api_port)
       http.read_timeout = config.rabbitmq_api_read_timeout
       http.write_timeout = config.rabbitmq_api_write_timeout if http.respond_to?(:write_timeout=)
       # don't do this in production:

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -159,8 +159,6 @@ module Beetle
       server = uri.port ? "#{uri.hostname}:#{uri.port}" : uri.hostname
       connection_options = config.connection_options_for_server(server)
 
-      $stderr.puts "Running request to #{uri} with options: #{connection_options.inspect}"
-
       request.basic_auth(connection_options[:user], connection_options[:pass])
       case request.class::METHOD
       when 'GET'
@@ -168,7 +166,8 @@ module Beetle
       when 'PUT'
         request["Content-Type"] = "application/json"
       end
-      http = Net::HTTP.new(connection_options[:host], connection_options[:api_port])
+      api_port = "1#{connection_options[:port]}".to_i
+      http = Net::HTTP.new(connection_options[:host], api_port)
       http.use_ssl = !!connection_options[:ssl] 
       http.read_timeout = config.rabbitmq_api_read_timeout
       http.write_timeout = config.rabbitmq_api_write_timeout if http.respond_to?(:write_timeout=)

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -159,14 +159,14 @@ module Beetle
       server = uri.port ? "#{uri.hostname}:#{uri.port}" : uri.hostname
       connection_options = config.connection_options_for_server(server)
 
-      request.basic_auth(connection_options.user, connection_options.pass)
+      request.basic_auth(connection_options[:user], connection_options[:pass])
       case request.class::METHOD
       when 'GET'
         request["Accept"] = "application/json"
       when 'PUT'
         request["Content-Type"] = "application/json"
       end
-      http = Net::HTTP.new(connection_options.host, connection_options.api_port)
+      http = Net::HTTP.new(connection_options[:host], connection_options[:api_port])
       http.read_timeout = config.rabbitmq_api_read_timeout
       http.write_timeout = config.rabbitmq_api_write_timeout if http.respond_to?(:write_timeout=)
       # don't do this in production:

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -167,8 +167,10 @@ module Beetle
         request["Content-Type"] = "application/json"
       end
       http = Net::HTTP.new(connection_options[:host], connection_options[:api_port])
+      http.use_ssl = !!connection_options[:ssl] 
       http.read_timeout = config.rabbitmq_api_read_timeout
       http.write_timeout = config.rabbitmq_api_write_timeout if http.respond_to?(:write_timeout=)
+
       # don't do this in production:
       # http.set_debug_output(logger.instance_eval{ @logdev.dev })
       http.start do |instance|

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -46,10 +46,7 @@ module Beetle
 
       # no need to worry that the server has the port 5672. Net:HTTP will take care of this. See below.
       policy_name = "#{queue_name}_policy"
-      request_url = URI("http://#{server}/api/policies/#{vhost}/#{policy_name}")
-      get_request = Net::HTTP::Get.new(request_url)
-      put_request = Net::HTTP::Put.new(request_url)
-      delete_request = Net::HTTP::Delete.new(request_url)
+      request_path = "/api/policies/#{vhost}/#{policy_name}"
 
       # set up queue policy
       definition = {}
@@ -70,9 +67,7 @@ module Beetle
 
       is_default_policy = definition == config.broker_default_policy
 
-      get_response = run_rabbit_http_request(request_url, get_request) do |http|
-        http.request(get_request, nil)
-      end
+      get_response = run_api_request(server, Net::HTTP::Get, request_path)
 
       case get_response.code
       when "200"
@@ -80,19 +75,16 @@ module Beetle
         same_policy = put_request_body.all? { |k,v| response_body[k] == v }
         if same_policy
           if is_default_policy
-            run_rabbit_http_request(request_url, delete_request) do |http|
-              http.request(get_request, nil)
-            end
+            run_api_request(server, Net::HTTP::Delete, request_path)
           end
+
           return :ok
         end
       when "404"
         return :ok if is_default_policy
       end
 
-      put_response = run_rabbit_http_request(request_url, put_request) do |http|
-        http.request(put_request, put_request_body.to_json)
-      end
+      put_response = run_api_request(server, Net::HTTP::Put, request_path, put_request_body.to_json)
 
       unless %w(200 201 204).include?(put_response.code)
         log_error("Failed to create policy for queue #{queue_name}", put_response)
@@ -125,12 +117,7 @@ module Beetle
     end
 
     def retrieve_bindings(server, queue_name)
-      request_url = URI("http://#{server}/api/queues/#{vhost}/#{queue_name}/bindings")
-      request = Net::HTTP::Get.new(request_url)
-
-      response = run_rabbit_http_request(request_url, request) do |http|
-        http.request(request)
-      end
+      response = run_api_request(server, Net::HTTP::Get, "/api/queues/#{vhost}/#{queue_name}/bindings")
 
       unless response.code == "200"
         log_error("Failed to retrieve bindings for queue #{queue_name}", response)
@@ -141,12 +128,7 @@ module Beetle
     end
 
     def remove_binding(server, queue_name, exchange, properties_key)
-      request_url = URI("http://#{server}/api/bindings/#{vhost}/e/#{exchange}/q/#{queue_name}/#{properties_key}")
-      request = Net::HTTP::Delete.new(request_url)
-
-      response = run_rabbit_http_request(request_url, request) do |http|
-        http.request(request)
-      end
+      response = run_api_request(server, Net::HTTP::Delete, "/api/bindings/#{vhost}/e/#{exchange}/q/#{queue_name}/#{properties_key}")
 
       unless %w(200 201 204).include?(response.code)
         log_error("Failed to remove obsolete binding for queue #{queue_name}", response)
@@ -154,27 +136,29 @@ module Beetle
       end
     end
 
-    def run_rabbit_http_request(uri, request, &block)
-      server             = uri.port ? "#{uri.hostname}:#{uri.port}" : uri.hostname
+    def run_api_request(server, request_const, path, *request_args)
       connection_options = config.connection_options_for_server(server)
-      api_port           = "1#{connection_options[:port]}".to_i
 
-      request.basic_auth(connection_options[:user], connection_options[:pass])
-      case request.class::METHOD
-      when 'GET'
-        request["Accept"] = "application/json"
-      when 'PUT'
-        request["Content-Type"] = "application/json"
+      derived_api_port = "1#{connection_options[:port]}".to_i
+      request_url = URI("http://#{connection_options[:host]}:#{derived_api_port}#{path}")
+
+      request = request_const.new(request_url).tap do |req|
+        req.basic_auth(connection_options[:user], connection_options[:pass])
+        case request_const::METHOD
+        when 'GET'
+          req["Accept"] = "application/json"
+        when 'PUT'
+          req["Content-Type"] = "application/json"
+        end
       end
-      http = Net::HTTP.new(connection_options[:host], api_port)
+
+      http = Net::HTTP.new(connection_options[:host], derived_api_port)
       http.use_ssl = !!connection_options[:ssl]
       http.read_timeout = config.rabbitmq_api_read_timeout
       http.write_timeout = config.rabbitmq_api_write_timeout if http.respond_to?(:write_timeout=)
 
-      # don't do this in production:
-      #http.set_debug_output(logger.instance_eval{ @logdev.dev })
       http.start do |instance|
-        block.call(instance) if block_given?
+        instance.request(request, *request_args)
       end
     end
 

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -159,6 +159,8 @@ module Beetle
       server = uri.port ? "#{uri.hostname}:#{uri.port}" : uri.hostname
       connection_options = config.connection_options_for_server(server)
 
+      $stderr.puts "Running request to #{uri} with options: #{connection_options.inspect}"
+
       request.basic_auth(connection_options[:user], connection_options[:pass])
       case request.class::METHOD
       when 'GET'

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -229,9 +229,15 @@ module Beetle
     end
 
     def connection_settings
+      options = connection_options_for_server(@server)
+
       {
-        :host => current_host, :port => current_port, :logging => false,
-        :user => @client.config.user, :pass => @client.config.password, :vhost => @client.config.vhost,
+        :host => options[:host],
+        :port => options[:port],
+        :user => options[:user],
+        :pass => options[:pass],
+        :vhost => options[:vhost],
+        :logging => false,
         :on_tcp_connection_failure => on_tcp_connection_failure,
         :on_possible_authentication_failure => on_possible_authentication_failure,
       }

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -33,6 +33,7 @@ module Beetle
     def listen_queues(queues) #:nodoc:
       @listened_queues = queues
       @exchanges_for_queues = exchanges_for_queues(queues)
+
       EM.run do
         each_server_sorted_randomly do
           connect_server connection_settings
@@ -230,13 +231,13 @@ module Beetle
 
     def connection_settings
       options = connection_options_for_server(@server)
-
       {
         :host => options[:host],
         :port => options[:port],
         :user => options[:user],
         :pass => options[:pass],
         :vhost => options[:vhost],
+        :ssl   => options[:ssl],
         :logging => false,
         :on_tcp_connection_failure => on_tcp_connection_failure,
         :on_possible_authentication_failure => on_possible_authentication_failure,

--- a/lib/beetle/version.rb
+++ b/lib/beetle/version.rb
@@ -1,3 +1,3 @@
 module Beetle
-  VERSION = "3.5.7"
+  VERSION = "4.0.0"
 end

--- a/test/beetle/base_test.rb
+++ b/test/beetle/base_test.rb
@@ -111,6 +111,5 @@ module Beetle
       @client.expects(:update_queue_properties!).with(options.merge(:server => "localhost:5672"))
       @bs.__send__(:publish_policy_options, options)
     end
-
   end
 end

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -70,6 +70,7 @@ module Beetle
   end
 
   class ConnectionOptionsForServerTest < Minitest::Test
+
     test "returns the options for the server provided" do
       config = Configuration.new
       config.servers = 'localhost:5672'
@@ -85,7 +86,7 @@ module Beetle
       end
     end
 
-    test "returns default options if no options are set for the server" do
+    test "returns default options if no specific options are set for the server" do
       config = Configuration.new
       config.servers = 'localhost:5672'
 

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -74,7 +74,7 @@ module Beetle
     test "returns the options for the server provided" do
       config = Configuration.new
       config.servers = 'localhost:5672'
-      config.server_connection_options["localhost:5672"] = {host:  'localhost', port: 5672, user: "john", pass: "doe", vhost: "test", ssl: "0"}
+      config.server_connection_options["localhost:5672"] = {host:  'localhost', port: 5672, user: "john", pass: "doe", vhost: "test", ssl: 0}
 
       config.connection_options_for_server("localhost:5672").tap do |options|
         assert_equal "localhost", options[:host]
@@ -82,7 +82,7 @@ module Beetle
         assert_equal "john", options[:user]
         assert_equal "doe", options[:pass]
         assert_equal "test", options[:vhost]
-        assert_equal "0", options[:ssl]
+        assert_equal 0, options[:ssl]
       end
     end
 
@@ -103,7 +103,7 @@ module Beetle
     test "allows to set specific options while retaining defaults for the rest" do
       config = Configuration.new
       config.servers = 'localhost:5672'
-      config.server_connection_options["localhost:5672"] = { pass: "another_pass", ssl: "1" }
+      config.server_connection_options["localhost:5672"] = { pass: "another_pass", ssl: 1 }
 
       config.connection_options_for_server("localhost:5672").tap do |options|
         assert_equal "localhost", options[:host]
@@ -111,7 +111,7 @@ module Beetle
         assert_equal "guest", options[:user]
         assert_equal "another_pass", options[:pass]
         assert_equal "/", options[:vhost]
-        assert_equal "1", options[:ssl]
+        assert_equal 1, options[:ssl]
       end
     end
   end

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -68,4 +68,50 @@ module Beetle
       assert_equal "10.0.0.1:3001", config.additional_subscription_servers
     end
   end
+
+  class ConnectionOptionsForServerTest < Minitest::Test
+    test "returns the options for the server provided" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+      config.server_connection_options["localhost:5672"] = {host:  'localhost', port: 5672, user: "john", pass: "doe", vhost: "test", ssl: "0"}
+
+      config.connection_options_for_server("localhost:5672").tap do |options|
+        assert_equal "localhost", options[:host]
+        assert_equal 5672, options[:port]
+        assert_equal "john", options[:user]
+        assert_equal "doe", options[:pass]
+        assert_equal "test", options[:vhost]
+        assert_equal "0", options[:ssl]
+      end
+    end
+
+    test "returns default options if no options are set for the server" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+
+      config.connection_options_for_server("localhost:5672").tap do |options|
+        assert_equal "localhost", options[:host]
+        assert_equal 5672, options[:port]
+        assert_equal "guest", options[:user]
+        assert_equal "guest", options[:pass]
+        assert_equal "/", options[:vhost]
+        assert_nil options[:ssl]
+      end
+    end
+
+    test "allows to set specific options while retaining defaults for the rest" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+      config.server_connection_options["localhost:5672"] = { pass: "another_pass", ssl: "1" }
+
+      config.connection_options_for_server("localhost:5672").tap do |options|
+        assert_equal "localhost", options[:host]
+        assert_equal 5672, options[:port]
+        assert_equal "guest", options[:user]
+        assert_equal "another_pass", options[:pass]
+        assert_equal "/", options[:vhost]
+        assert_equal "1", options[:ssl]
+      end
+    end
+  end
 end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -23,6 +23,7 @@ module Beetle
         :user => "guest",
         :pass => "guest",
         :vhost => "/",
+        :ssl => nil,
         :socket_timeout => 0,
         :connect_timeout => 5,
         :frame_max => 131072,

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -35,6 +35,34 @@ module Beetle
       assert_equal m, @pub.send(:new_bunny)
     end
 
+    test "new bunnies should be created using custom connection options and they should be started" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+      config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: "0" }
+      client = Client.new(config)
+      pub = Publisher.new(client)
+
+      m = mock("dummy")
+      expected_bunny_options = {
+        host: "localhost",
+        port: 5672,
+        user: "john",
+        pass: "doe",
+        vhost: "test",
+        ssl: "0",
+        socket_timeout: 0,
+        connect_timeout: 5,
+        frame_max: 131072,
+        channel_max: 2047,
+        spec: '09',
+        logging: false
+      }
+    
+      Bunny.expects(:new).with(expected_bunny_options).returns(m)
+      m.expects(:start)
+      assert_equal m, pub.send(:new_bunny)
+    end
+
     test "initially there should be no bunnies" do
       assert_equal({}, @pub.instance_variable_get("@bunnies"))
     end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -38,18 +38,18 @@ module Beetle
     test "new bunnies should be created using custom connection options and they should be started" do
       config = Configuration.new
       config.servers = 'localhost:5672'
-      config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: "0" }
+      config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: 0 }
       client = Client.new(config)
       pub = Publisher.new(client)
 
-      m = mock("dummy")
+      bunny_mock = mock("dummy_bunny")
       expected_bunny_options = {
         host: "localhost",
         port: 5672,
         user: "john",
         pass: "doe",
         vhost: "test",
-        ssl: "0",
+        ssl: 0,
         socket_timeout: 0,
         connect_timeout: 5,
         frame_max: 131072,
@@ -57,10 +57,10 @@ module Beetle
         spec: '09',
         logging: false
       }
-    
-      Bunny.expects(:new).with(expected_bunny_options).returns(m)
-      m.expects(:start)
-      assert_equal m, pub.send(:new_bunny)
+
+      Bunny.expects(:new).with(expected_bunny_options).returns(bunny_mock)
+      bunny_mock.expects(:start)
+      assert_equal bunny_mock, pub.send(:new_bunny)
     end
 
     test "initially there should be no bunnies" do

--- a/test/beetle/queue_properties_test.rb
+++ b/test/beetle/queue_properties_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
-require 'pry'
 
 module Beetle
   class RabbitMQApiConnectionTest < Minitest::Spec
@@ -22,7 +21,7 @@ module Beetle
                  .with(basic_auth: ['guest', 'guest'])
                  .to_return(status: 200)
 
-        queue_properties.run_rabbit_http_request(request_uri, request) { |http| http.request(request) }
+        queue_properties.run_api_request(server, Net::HTTP::Get, "/api/test")
 
         assert_requested(stub)
       end
@@ -37,7 +36,19 @@ module Beetle
                  .with(basic_auth: ['john', 'doe'])
                  .to_return(status: 200)
 
-        queue_properties.run_rabbit_http_request(request_uri, request) { |http| http.request(request) }
+        queue_properties.run_api_request(server, Net::HTTP::Get, "/api/test")
+
+        assert_requested(stub)
+      end
+    end
+
+    describe "when server does not specify a port" do
+      let(:server) { "noport.example.com" }
+
+      test "derives correct api port" do
+        stub = stub_request(:get, "http://noport.example.com:15672/api/test").to_return(status: 200)
+
+        queue_properties.run_api_request(server, Net::HTTP::Get, "/api/test")
 
         assert_requested(stub)
       end

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -118,7 +118,6 @@ module Beetle
       @sub.stubs(:queues).returns("a" => q)
       @sub.__send__(:resume, "a")
     end
-
   end
 
   class AdditionalSubscriptionServersTest < Minitest::Test
@@ -415,12 +414,15 @@ module Beetle
       assert_equal({:ack => true}, opts)
       assert_equal 42, block.call(1)
     end
-
   end
 
   class ConnectionTest < Minitest::Test
     def setup
-      @client = Client.new
+      @config = Beetle::Configuration.new
+      @config.servers = "mickey:42"
+      @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: "0" }
+
+      @client = Client.new(@config)
       @sub = @client.send(:subscriber)
       @sub.send(:set_current_server, "mickey:42")
       @settings = @sub.send(:connection_settings)
@@ -470,6 +472,30 @@ module Beetle
       assert_equal connection, @sub.instance_variable_get("@connections")["mickey:42"]
     end
 
+    test "uses server connection options" do
+      @client.register_exchange(:an_exchange)
+      @client.register_queue(:a_queue, :exchange => :an_exchange)
+      @client.register_message(:a_message, :key => "foo", :exchange => :an_exchange)
+
+      connection = mock("connection")
+
+      connection.expects(:on_tcp_connection_loss)
+      connection.expects(:next_channel_id).returns(1)
+      connection.expects(:auto_recovering?).returns(true)
+      connection.expects(:open?).returns(true)
+      connection.expects(:channel_max)
+      connection.expects(:on_connection)
+
+
+      EM.expects(:run).yields
+      EM.expects(:reactor_running?).returns(true)
+
+      AMQP.expects(:connect).once.with(has_entries(host: "mickey", port: 42, user: "john", pass: "doe", ssl: "0")).yields(connection)
+
+      @sub.listen_queues(["a_queue"])
+    end
+    
+
     test "channel opening, exchange creation, queue bindings and subscription" do
       connection = mock("connection")
       channel = mock("channel")
@@ -482,7 +508,5 @@ module Beetle
       @sub.send(:open_channel_and_subscribe, connection, @settings)
       assert_equal channel, @sub.instance_variable_get("@channels")["mickey:42"]
     end
-
   end
-
 end

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -420,7 +420,7 @@ module Beetle
     def setup
       @config = Beetle::Configuration.new
       @config.servers = "mickey:42"
-      @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: "0" }
+      @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: 0 }
 
       @client = Client.new(@config)
       @sub = @client.send(:subscriber)
@@ -490,7 +490,7 @@ module Beetle
       EM.expects(:run).yields
       EM.expects(:reactor_running?).returns(true)
 
-      AMQP.expects(:connect).once.with(has_entries(host: "mickey", port: 42, user: "john", pass: "doe", ssl: "0")).yields(connection)
+      AMQP.expects(:connect).once.with(has_entries(host: "mickey", port: 42, user: "john", pass: "doe", ssl: 0)).yields(connection)
 
       @sub.listen_queues(["a_queue"])
     end


### PR DESCRIPTION
This adds the possibility to configure connection options on a per server basis.

It introduces a new configuration setting `server_connection_options` which is a Hash, that maps a servername to a hash of options with keys `host, port, user, pass, vhost, ssl`. Those options default to the corresponding settings in the configuration.

In essence this allows us to configure specific options for individual servers and leave the rest as is.
This is required to add an AmazonMQ broker, which requires different credentials and TLS.

## Breaking changes

This change removes the `Beetle::Configuration.api_port` attribute accessor without a replacement.
Instead the API port is always derived from the server's amqp port by prepending a 1.

## Implementation note

This change is not the best in terms of software design, but the overall objective for me was to keep the change minimal, and minimize risks of unintended breakage. I don't know the codebase very well, and we intend to update many clients with this change, so we need to play safe.

Additionally, we plan to deprecate and remove the library soon, so it really doesn't make sense to make it extra pretty and ready for evolution.

## Release plan

We intent to integrate this change into a new release branch `v4.x` in order to keep upstream relatively undisturbed.
This PR targets that branch already.

## Testing

We will test this change end-to-end in multiple steps. 

- [x] Integrate in one of our applications in an isolated environment with a default (non-AWS) config
- [x] Integrate in one of our applications in an isolated environment which configures both AWS and on-prem brokers
- [x] Test end-to-end that it also works for additional subscription servers
- [x] Integrate on our preview environment in one of our applications


## Todo

- [x] Decide on strartegy to roll-out (integration branch or version bump directly?)
   - we create a new major version and corresponding branch (if that's not enough we can even release under a new name)
   - release to 1, few, all (start with our app, find a small cohort of other apps, release to everyone in the organisation)
- [x] Test change with xing-amqp

## Refs
  * APII-1589 