### PR TITLE
Tests against different activerecord/activesupport versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           go-version: '1.20.7'
 
-      - name: Install dependencies
-        run: sudo apt-get install redis
-
       - name: Start required services
         run: docker compose up -d
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         ruby-version: [3.3.4, 3.2.5, 3.1.6]
         redis-version: [4, 5]
+        rails-version: [6.1.7.8, 7.0.8.4, 7.1.3.4, 7.2.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -35,22 +36,22 @@ jobs:
       - name: Start required services
         run: docker compose up -d
 
-      - name: Install gems
-        run: bundle install && bundle exec appraisal install
+      - name: Generate appraisal files
+        run: bundle install && bundle exec appraisal generate
 
       - name: Compile and test beetle go binary
         run: make && make test
 
-      - name: Run beetle gem tests
-        run: bundle exec rake test
+      - name: Install gems and run beetle gem tests
+        run: bundle install && bundle exec rake test
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}.gemfile
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
           MINITEST_REPORTER: SpecReporter
 
       - name: Run beetle failover tests
         run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}.gemfile
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
 
       - name: Stop services
         run: docker compose down

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby-version: [3.3.4, 3.2.5, 3.1.6]
         redis-version: [4, 5]
-        activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4, 7.2.0]
+        activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           go-version: '1.20.7'
 
+      - name: Install dependencies
+        run: sudo apt-get install redis
+
       - name: Start required services
         run: docker compose up -d
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby-version: [3.1.6, 3.2.5, 3.3.4]
         redis-version: [4, 5]
-        activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
+        rails-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,13 +45,13 @@ jobs:
       - name: Install gems and run beetle gem tests
         run: bundle install && bundle exec rake test
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
           MINITEST_REPORTER: SpecReporter
 
       - name: Run beetle failover tests
         run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
 
       - name: Stop services
         run: docker compose down

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ on:
     branches: [ master ]
 
 jobs:
-  ruby-tests:
+  test:
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby-version: [3.3.4]
-        redis-version: [5]
-        activerecord-version: [7.1.3.4]
+        ruby-version: [3.3.4, 3.2.5, 3.1.6]
+        redis-version: [4, 5]
+        activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,37 +24,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - name: Install dependencies
-        run: sudo apt-get install redis
-
-      - name: Start required services
-        run: docker compose up -d
-
-      - name: Generate appraisal files
-        run: bundle install && bundle exec appraisal generate
-
-      - name: Install gems and run beetle gem tests
-        run: bundle install && bundle exec rake test
-        env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
-          MINITEST_REPORTER: SpecReporter
-
-      - name: Run beetle failover tests
-        run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
-        env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
-
-      - name: Stop services
-        run: docker compose down
-        if: always()
-
-  go-tests:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
@@ -67,8 +36,22 @@ jobs:
       - name: Start required services
         run: docker compose up -d
 
+      - name: Generate appraisal files
+        run: bundle install && bundle exec appraisal generate
+
       - name: Compile and test beetle go binary
         run: make && make test
+
+      - name: Install gems and run beetle gem tests
+        run: bundle install && bundle exec rake test
+        env:
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
+          MINITEST_REPORTER: SpecReporter
+
+      - name: Run beetle failover tests
+        run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
+        env:
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
 
       - name: Stop services
         run: docker compose down

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.3.4, 3.2.5, 3.1.6]
+        ruby-version: [3.1.6, 3.2.5, 3.3.4]
         redis-version: [4, 5]
         activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby-version: [3.3.4, 3.2.5, 3.1.6]
         redis-version: [4, 5]
-        rails-version: [6.1.7.8, 7.0.8.4, 7.1.3.4, 7.2.0]
+        activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4, 7.2.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,13 +45,13 @@ jobs:
       - name: Install gems and run beetle gem tests
         run: bundle install && bundle exec rake test
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
           MINITEST_REPORTER: SpecReporter
 
       - name: Run beetle failover tests
         run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
 
       - name: Stop services
         run: docker compose down

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  ruby-tests:
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby-version: [3.3.4, 3.2.5, 3.1.6]
-        redis-version: [4, 5]
-        activerecord-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
+        ruby-version: [3.3.4]
+        redis-version: [5]
+        activerecord-version: [7.1.3.4]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,6 +24,37 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Install dependencies
+        run: sudo apt-get install redis
+
+      - name: Start required services
+        run: docker compose up -d
+
+      - name: Generate appraisal files
+        run: bundle install && bundle exec appraisal generate
+
+      - name: Install gems and run beetle gem tests
+        run: bundle install && bundle exec rake test
+        env:
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
+          MINITEST_REPORTER: SpecReporter
+
+      - name: Run beetle failover tests
+        run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
+        env:
+          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
+
+      - name: Stop services
+        run: docker compose down
+        if: always()
+
+  go-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
@@ -36,22 +67,8 @@ jobs:
       - name: Start required services
         run: docker compose up -d
 
-      - name: Generate appraisal files
-        run: bundle install && bundle exec appraisal generate
-
       - name: Compile and test beetle go binary
         run: make && make test
-
-      - name: Install gems and run beetle gem tests
-        run: bundle install && bundle exec rake test
-        env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
-          MINITEST_REPORTER: SpecReporter
-
-      - name: Run beetle failover tests
-        run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
-        env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_activerecord_${{ matrix.activerecord-version }}.gemfile
 
       - name: Stop services
         run: docker compose down

--- a/Appraisals
+++ b/Appraisals
@@ -1,18 +1,20 @@
 # keep the same versions in .github/workflows/build.yml
-activerecord_versions = [
+rails_versions = [
   "6.1.7.8",
   "7.0.8.4",
   "7.1.3.4",
   "7.2.0"
 ]
-activerecord_versions.each do |activerecord_version|
-  appraise "redis_4_activerecord_#{activerecord_version}" do
+rails_versions.each do |rails_version|
+  appraise "redis_4_activerecord_#{rails_version}" do
     gem "redis", "~> 4.0"
-    gem "activerecord", activerecord_version
+    gem "activerecord", rails_version
+    gem "activesupport", rails_version
   end
-  appraise "redis_5_activerecord_#{activerecord_version}" do
+  appraise "redis_5_activerecord_#{rails_version}" do
     gem "redis", "~> 5.0"
     gem "hiredis-client"
-    gem "activerecord", activerecord_version
+    gem "activerecord", rails_version
+    gem "activesupport", rails_version
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -6,12 +6,12 @@ rails_versions = [
   "7.2.0"
 ]
 rails_versions.each do |rails_version|
-  appraise "redis_4_activerecord_#{rails_version}" do
+  appraise "redis_4_rails_#{rails_version}" do
     gem "redis", "~> 4.0"
     gem "activerecord", rails_version
     gem "activesupport", rails_version
   end
-  appraise "redis_5_activerecord_#{rails_version}" do
+  appraise "redis_5_rails_#{rails_version}" do
     gem "redis", "~> 5.0"
     gem "hiredis-client"
     gem "activerecord", rails_version

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,18 @@
-appraise "redis-4" do
-  gem "redis", "~> 4.0"
-end
-appraise "redis-5" do
-  gem "redis", "~> 5.0"
-  gem "hiredis-client"
+# keep the same versions in .github/workflows/build.yml
+rails_versions = [
+  "6.1.7.8",
+  "7.0.8.4",
+  "7.1.3.4",
+  "7.2.0"
+]
+rails_versions.each do |rails_version|
+  appraise "redis_4_rails_#{rails_version}" do
+    gem "redis", "~> 4.0"
+    gem "rails", rails_version
+  end
+  appraise "redis_5_rails_#{rails_version}" do
+    gem "redis", "~> 5.0"
+    gem "hiredis-client"
+    gem "rails", rails_version
+  end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,18 +1,18 @@
 # keep the same versions in .github/workflows/build.yml
-rails_versions = [
+activerecord_versions = [
   "6.1.7.8",
   "7.0.8.4",
   "7.1.3.4",
   "7.2.0"
 ]
-rails_versions.each do |rails_version|
-  appraise "redis_4_rails_#{rails_version}" do
+activerecord_versions.each do |activerecord_version|
+  appraise "redis_4_activerecord_#{activerecord_version}" do
     gem "redis", "~> 4.0"
-    gem "rails", rails_version
+    gem "activerecord", activerecord_version
   end
-  appraise "redis_5_rails_#{rails_version}" do
+  appraise "redis_5_activerecord_#{activerecord_version}" do
     gem "redis", "~> 5.0"
     gem "hiredis-client"
-    gem "rails", rails_version
+    gem "activerecord", activerecord_version
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gem "hiredis-client"
 
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
 
-# Use patched appraisal gem until it is fixed upstream.
-gem "appraisal", git: "https://github.com/toy/appraisal.git", ref: "55334f67f96448c2209648a20ccaeb3800a6ab0f"
+gem "appraisal", '~> 2.5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gemspec
 gem "hiredis-client"
 
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
-
-gem "appraisal", '~> 2.5.0'

--- a/beetle.gemspec
+++ b/beetle.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "amqp",                    "= 1.8.0"
   s.add_runtime_dependency "activesupport",           ">= 2.3.4"
 
-  s.add_development_dependency "activerecord",        "~> 5.0"
+  s.add_development_dependency "activerecord",        ">= 6.1"
   s.add_development_dependency "cucumber",            "~> 8.0.0"
   s.add_development_dependency "daemon_controller",   "~> 1.2.0"
   s.add_development_dependency "daemons",             ">= 1.2.0"
@@ -48,5 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "redcarpet"
   s.add_development_dependency "github-markup"
   s.add_development_dependency "byebug"
-  s.add_development_dependency "appraisal"
+  s.add_development_dependency "appraisal",          ">= 2.5.0"
 end


### PR DESCRIPTION
Currently tests don't run against different activerecord versions, but just assumed everything is like in activerecord 5.

- [x] Use released appraisal gem, issue for using from github.com was released in 2.5.0
- [x] Test against ~4~3 different activerecord versions `[6.1.7.8, 7.0.8.4, 7.1.3.4]` (`7.2.0` fails currently, so would only enable it together with the fix)
- [x] Use appraisal generate to avoid installing all gem versions on all builds
- [x] ~Can we move out the go tests, since they are independent of the ruby/redis/activerecord matrix? Currently they run on all of them~ we can't, because failover tests require beetle binary created in the go step