### PR TITLE
Use true and false for ssl option

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -169,7 +169,7 @@ module Beetle
         :user               => options[:user],
         :pass               => options[:pass],
         :vhost              => options[:vhost],
-        :ssl                => options[:ssl],
+        :ssl                => options[:ssl] || false,
         :frame_max          => @client.config.frame_max,
         :channel_max        => @client.config.channel_max,
         :socket_timeout     => @client.config.publishing_timeout,

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -153,7 +153,7 @@ module Beetle
       end
 
       http = Net::HTTP.new(connection_options[:host], derived_api_port)
-      http.use_ssl = !!connection_options[:ssl]
+      http.use_ssl = connection_options[:ssl]
       http.read_timeout = config.rabbitmq_api_read_timeout
       http.write_timeout = config.rabbitmq_api_write_timeout if http.respond_to?(:write_timeout=)
 

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -74,7 +74,7 @@ module Beetle
     test "returns the options for the server provided" do
       config = Configuration.new
       config.servers = 'localhost:5672'
-      config.server_connection_options["localhost:5672"] = {host:  'localhost', port: 5672, user: "john", pass: "doe", vhost: "test", ssl: 0}
+      config.server_connection_options["localhost:5672"] = {host:  'localhost', port: 5672, user: "john", pass: "doe", vhost: "test", ssl: false}
 
       config.connection_options_for_server("localhost:5672").tap do |options|
         assert_equal "localhost", options[:host]
@@ -82,7 +82,7 @@ module Beetle
         assert_equal "john", options[:user]
         assert_equal "doe", options[:pass]
         assert_equal "test", options[:vhost]
-        assert_equal 0, options[:ssl]
+        assert_equal false, options[:ssl]
       end
     end
 
@@ -103,7 +103,7 @@ module Beetle
     test "allows to set specific options while retaining defaults for the rest" do
       config = Configuration.new
       config.servers = 'localhost:5672'
-      config.server_connection_options["localhost:5672"] = { pass: "another_pass", ssl: 1 }
+      config.server_connection_options["localhost:5672"] = { pass: "another_pass", ssl: true }
 
       config.connection_options_for_server("localhost:5672").tap do |options|
         assert_equal "localhost", options[:host]
@@ -111,7 +111,7 @@ module Beetle
         assert_equal "guest", options[:user]
         assert_equal "another_pass", options[:pass]
         assert_equal "/", options[:vhost]
-        assert_equal 1, options[:ssl]
+        assert_equal true, options[:ssl]
       end
     end
   end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -23,7 +23,7 @@ module Beetle
         :user => "guest",
         :pass => "guest",
         :vhost => "/",
-        :ssl => nil,
+        :ssl => false,
         :socket_timeout => 0,
         :connect_timeout => 5,
         :frame_max => 131072,
@@ -38,7 +38,7 @@ module Beetle
     test "new bunnies should be created using custom connection options and they should be started" do
       config = Configuration.new
       config.servers = 'localhost:5672'
-      config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: 0 }
+      config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
       client = Client.new(config)
       pub = Publisher.new(client)
 
@@ -49,7 +49,7 @@ module Beetle
         user: "john",
         pass: "doe",
         vhost: "test",
-        ssl: 0,
+        ssl: false,
         socket_timeout: 0,
         connect_timeout: 5,
         frame_max: 131072,

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -420,7 +420,7 @@ module Beetle
     def setup
       @config = Beetle::Configuration.new
       @config.servers = "mickey:42"
-      @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: 0 }
+      @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
 
       @client = Client.new(@config)
       @sub = @client.send(:subscriber)
@@ -490,11 +490,11 @@ module Beetle
       EM.expects(:run).yields
       EM.expects(:reactor_running?).returns(true)
 
-      AMQP.expects(:connect).once.with(has_entries(host: "mickey", port: 42, user: "john", pass: "doe", ssl: 0)).yields(connection)
+      AMQP.expects(:connect).once.with(has_entries(host: "mickey", port: 42, user: "john", pass: "doe", ssl: false)).yields(connection)
 
       @sub.listen_queues(["a_queue"])
     end
-    
+
 
     test "channel opening, exchange creation, queue bindings and subscription" do
       connection = mock("connection")


### PR DESCRIPTION
Bunny actually uses `true` and `false` for the `ssl` setting: https://github.com/ruby-amqp/bunny/blob/0.7.12/lib/qrack/client.rb#L51.

This PR changes the behavior to also use true and false for the `ssl` configuration. It also, instead of passing `ssl: nil` to `Bunny#new`, now defaults to `ssl: false` if the option is not set. 