### PR TITLE
Use ActiveRecord connection_handler to clear connections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby-version: [3.1.6, 3.2.5, 3.3.4]
         redis-version: [4, 5]
-        rails-version: [6.1.7.8, 7.0.8.4, 7.1.3.4]
+        rails-version: [6.1.7.8, 7.0.8.4, 7.1.4, 7.2.1]
 
     steps:
       - uses: actions/checkout@v3

--- a/Appraisals
+++ b/Appraisals
@@ -2,8 +2,8 @@
 rails_versions = [
   "6.1.7.8",
   "7.0.8.4",
-  "7.1.3.4",
-  "7.2.0"
+  "7.1.4",
+  "7.2.1"
 ]
 rails_versions.each do |rails_version|
   appraise "redis_4_rails_#{rails_version}" do

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -338,12 +338,12 @@ module Beetle
       Timer.timeout(@timeout.to_f) { @handler_result = handler.call(self) }
       RC::OK
     rescue Exception => @exception
-      ActiveRecord::Base.clear_all_connections! if defined?(ActiveRecord)
+      ActiveRecord::Base.connection_handler.clear_all_connections! if defined?(ActiveRecord)
       Beetle::reraise_expectation_errors!
       logger.debug "Beetle: message handler crashed on #{msg_id}"
       RC::HandlerCrash
     ensure
-      ActiveRecord::Base.clear_active_connections! if defined?(ActiveRecord)
+      ActiveRecord::Base.connection_handler.clear_active_connections! if defined?(ActiveRecord)
     end
 
     def run_handler!(handler)


### PR DESCRIPTION
This PR makes the gem compatible with rails 7.2.x, where the deprecated methods were removed from ActiveRecord::Base