### PR TITLE
Thread local channels

### DIFF
--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Beetle
   # Provides a thread-local storage for channels which must not be shared between threads.
   # The current implementation claims the :beetle_publisher_channels key in the current thread
@@ -8,16 +10,17 @@ module Beetle
   # of a hash as the underlying store (see also concurrent-ruby ThreadLocalVar). For our case however, this is good enough.
   class Channels
     def initialize
+      @uuid = SecureRandom.uuid
       Thread.current[:beetle_publisher_channels] ||= {}
-      Thread.current[:beetle_publisher_channels][object_id] = {}
+      Thread.current[:beetle_publisher_channels][@uuid] = {}
     end
 
     def []=(server, channel)
-      Thread.current[:beetle_publisher_channels][object_id][server] = channel
+      Thread.current[:beetle_publisher_channels][@uuid][server] = channel
     end
 
     def [](server)
-      Thread.current[:beetle_publisher_channels][object_id][server]
+      Thread.current[:beetle_publisher_channels][@uuid][server]
     end
   end
 end

--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -33,7 +33,7 @@ module Beetle
     end
 
     def cleanup!
-      Thread.current[:beetle_publisher_channels][@uuid] = {}
+      Thread.current[:beetle_publisher_channels].delete(@uuid)
     end
   end
 end

--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -1,0 +1,23 @@
+module Beetle
+  # Provides a thread-local storage for channels which must not be shared between threads.
+  # The current implmentation claims the :beetle_publisher_channels key in the current thread
+  # and maintains a hash that indexes object_ids to their channels.
+  # This way channels are thread scoped and instance scoped. (Multiple publishers can have distinct channels)
+  #
+  # Performance: Normally you'd want to have fast access to local variables, and an ideal implementation uses an array, instead
+  # of a hash as the underlying store (see also concurrent-ruby ThreadLocalVar). For our case howeverm, this is good enough.
+  class Channels
+    def initialize
+      Thread.current[:beetle_publisher_channels] ||= {}
+      Thread.current[:beetle_publisher_channels][object_id] = {}
+    end
+
+    def []=(server, channel)
+      Thread.current[:beetle_publisher_channels][object_id][server] = channel
+    end
+
+    def [](server)
+      Thread.current[:beetle_publisher_channels][object_id][server]
+    end
+  end
+end

--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -33,7 +33,7 @@ module Beetle
       Thread.current[:beetle_publisher_channels][@uuid][server]
     end
 
-    def cleanup
+    def cleanup!
       Thread.current[:beetle_publisher_channels][@uuid] = {}
     end
   end

--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -22,7 +22,6 @@ module Beetle
       @uuid = SecureRandom.uuid
       Thread.current[:beetle_publisher_channels] ||= {}
       Thread.current[:beetle_publisher_channels][@uuid] = {}
-      self.class.instances[self] = @uuid
     end
 
     def []=(server, channel)

--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -18,22 +18,24 @@ module Beetle
   # We can't use finalizers for that since they run on a different thread.
   # Best practice would be use `ensure` to cleanup the Channels instance once it's no longer needed.
   class Channels
+    THREAD_LOCAL_KEY = :beetle_publisher_channels
+
     def initialize
       @uuid = SecureRandom.uuid
-      Thread.current[:beetle_publisher_channels] ||= {}
-      Thread.current[:beetle_publisher_channels][@uuid] = {}
+      Thread.current[THREAD_LOCAL_KEY] ||= {}
+      Thread.current[THREAD_LOCAL_KEY][@uuid] = {}
     end
 
     def []=(server, channel)
-      Thread.current[:beetle_publisher_channels][@uuid][server] = channel
+      Thread.current[THREAD_LOCAL_KEY][@uuid][server] = channel
     end
 
     def [](server)
-      Thread.current[:beetle_publisher_channels][@uuid][server]
+      Thread.current[THREAD_LOCAL_KEY][@uuid][server]
     end
 
     def cleanup!
-      Thread.current[:beetle_publisher_channels].delete(@uuid)
+      Thread.current[THREAD_LOCAL_KEY].delete(@uuid)
     end
   end
 end

--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -1,11 +1,11 @@
 module Beetle
   # Provides a thread-local storage for channels which must not be shared between threads.
-  # The current implmentation claims the :beetle_publisher_channels key in the current thread
+  # The current implementation claims the :beetle_publisher_channels key in the current thread
   # and maintains a hash that indexes object_ids to their channels.
   # This way channels are thread scoped and instance scoped. (Multiple publishers can have distinct channels)
   #
   # Performance: Normally you'd want to have fast access to local variables, and an ideal implementation uses an array, instead
-  # of a hash as the underlying store (see also concurrent-ruby ThreadLocalVar). For our case howeverm, this is good enough.
+  # of a hash as the underlying store (see also concurrent-ruby ThreadLocalVar). For our case however, this is good enough.
   class Channels
     def initialize
       Thread.current[:beetle_publisher_channels] ||= {}

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -5,10 +5,10 @@ module Beetle
 
     def initialize(client, options = {}) #:nodoc:
       super
-      @channels = Channels.new
       @exchanges_with_bound_queues = {}
       @dead_servers = {}
       @bunnies = {}
+      @channels = Channels.new
       @throttling_options = {}
       @next_throttle_refresh = Time.now
       @throttled = false

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -192,7 +192,7 @@ module Beetle
       !!Thread.current[:beetle_publisher_channels][@server]
     end
 
-    def reset_channel
+    def reset_channel!
       Thread.current[:beetle_publisher_channels][@server] = nil 
     end
 
@@ -265,8 +265,8 @@ module Beetle
       logger.warn "Beetle: error closing down bunny: #{e}"
       Beetle::reraise_expectation_errors!
     ensure
-      @bunnies[@server] = nil
-      reset_channel
+      bunnies[@server] = nil
+      reset_channel!
       @exchanges[@server] = {}
       @queues[@server] = {}
     end

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -206,7 +206,7 @@ module Beetle
     end
 
     def channel
-      @channels[@sever] ||= bunny.create_channel
+      @channels[@server] ||= bunny.create_channel
     end
 
     def channel?

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -6,10 +6,11 @@ module Beetle
 
     def initialize(client, options = {}) #:nodoc:
       super
+      Thread.current[:beetle_publisher_channels] ||= {}
       @exchanges_with_bound_queues = {}
       @dead_servers = {}
       @bunnies = {}
-      @channels = {}
+      @channels = Thread.current[:beetle_publisher_channels] ||= {}
       @throttling_options = {}
       @next_throttle_refresh = Time.now
       @throttled = false
@@ -185,11 +186,11 @@ module Beetle
     end
 
     def channel
-      @channels[@server] ||= bunny.create_channel
+      Thread.current[:beetle_publisher_channels][@server] ||= bunny.create_channel
     end
 
     def channel?
-      !!@channels[@server]
+      !!Thread.current[:beetle_publisher_channels][@server]
     end
 
     # retry dead servers after ignoring them for 10.seconds

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -1,4 +1,11 @@
 module Beetle
+  # Provides a thread-local storage for channels which must not be shared between threads.
+  # The current implmentation claims the :beetle_publisher_channels key in the current thread
+  # and maintains a hash that indexes object_ids to their channels.
+  # This way channels are thread scoped and instance scoped. (Multiple publishers can have distinct channels)
+  # 
+  # Performance: Normally you'd want to have fast access to local variables, and an ideal implementation uses an array, instead
+  # of a hash as the underlying store (see also concurrent-ruby ThreadLocalVar). For our case howeverm, this is good enough.
   class Channels
     def initialize
       Thread.current[:beetle_publisher_channels] ||= {}

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -1,26 +1,4 @@
 module Beetle
-  # Provides a thread-local storage for channels which must not be shared between threads.
-  # The current implmentation claims the :beetle_publisher_channels key in the current thread
-  # and maintains a hash that indexes object_ids to their channels.
-  # This way channels are thread scoped and instance scoped. (Multiple publishers can have distinct channels)
-  # 
-  # Performance: Normally you'd want to have fast access to local variables, and an ideal implementation uses an array, instead
-  # of a hash as the underlying store (see also concurrent-ruby ThreadLocalVar). For our case howeverm, this is good enough.
-  class Channels
-    def initialize
-      Thread.current[:beetle_publisher_channels] ||= {}
-      Thread.current[:beetle_publisher_channels][object_id] = {}
-    end
-
-    def []=(server, channel)
-      Thread.current[:beetle_publisher_channels][object_id][server] = channel
-    end
-
-    def [](server)
-      Thread.current[:beetle_publisher_channels][object_id][server]
-    end
-  end
-
   # Provides the publishing logic implementation.
   class Publisher < Base
     attr_reader :dead_servers

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -265,7 +265,7 @@ module Beetle
       logger.warn "Beetle: error closing down bunny: #{e}"
       Beetle::reraise_expectation_errors!
     ensure
-      bunnies[@server] = nil
+      @bunnies[@server] = nil
       reset_channel!
       @exchanges[@server] = {}
       @queues[@server] = {}

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -10,7 +10,6 @@ module Beetle
       @exchanges_with_bound_queues = {}
       @dead_servers = {}
       @bunnies = {}
-      @channels = Thread.current[:beetle_publisher_channels] ||= {}
       @throttling_options = {}
       @next_throttle_refresh = Time.now
       @throttled = false
@@ -193,6 +192,10 @@ module Beetle
       !!Thread.current[:beetle_publisher_channels][@server]
     end
 
+    def reset_channel
+      Thread.current[:beetle_publisher_channels][@server] = nil 
+    end
+
     # retry dead servers after ignoring them for 10.seconds
     # if all servers are dead, retry the one which has been dead for the longest time
     def recycle_dead_servers
@@ -263,7 +266,7 @@ module Beetle
       Beetle::reraise_expectation_errors!
     ensure
       @bunnies[@server] = nil
-      @channels[@server] = nil
+      reset_channel
       @exchanges[@server] = {}
       @queues[@server] = {}
     end

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -191,10 +191,6 @@ module Beetle
       !!@channels[@server]
     end
 
-    def reset_channel!
-      @channels[@server] = nil
-    end
-
     # retry dead servers after ignoring them for 10.seconds
     # if all servers are dead, retry the one which has been dead for the longest time
     def recycle_dead_servers
@@ -265,7 +261,7 @@ module Beetle
       Beetle::reraise_expectation_errors!
     ensure
       @bunnies[@server] = nil
-      reset_channel!
+      @channels[@server] = nil
       @exchanges[@server] = {}
       @queues[@server] = {}
     end

--- a/test/beetle/channels_test.rb
+++ b/test/beetle/channels_test.rb
@@ -5,8 +5,12 @@ module Beetle
     test "allows to set new channel with key" do
       @channels = Beetle::Channels.new
       o = Object.new
+      o2 = Object.new
 
       @channels["key"] = o
+      assert_equal @channels["key"].object_id, o.object_id
+
+      @channels["key"] ||= o2
       assert_equal @channels["key"].object_id, o.object_id
     end
 

--- a/test/beetle/channels_test.rb
+++ b/test/beetle/channels_test.rb
@@ -1,0 +1,27 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+module Beetle
+  class ChannelsTest < Minitest::Test
+    test "allows to set new channel with key" do
+      @channels = Beetle::Channels.new
+      o = Object.new
+
+      @channels["key"] = o
+      assert_equal @channels["key"].object_id, o.object_id
+    end
+
+    test "multiple instances have their own state" do
+      @channels = Beetle::Channels.new
+      @channels2 = Beetle::Channels.new
+      o = Object.new
+      o2 = Object.new
+
+      @channels["key"] = o
+
+      assert_nil @channels2["key"]
+      @channels2["key"] = o2
+
+      refute_equal @channels["key"].object_id, @channels2["key"].object_id
+    end
+  end
+end

--- a/test/beetle/channels_test.rb
+++ b/test/beetle/channels_test.rb
@@ -17,10 +17,9 @@ module Beetle
       o2 = Object.new
 
       @channels["key"] = o
-
       assert_nil @channels2["key"]
-      @channels2["key"] = o2
 
+      @channels2["key"] = o2
       refute_equal @channels["key"].object_id, @channels2["key"].object_id
     end
   end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -118,6 +118,12 @@ module Beetle
       assert_nil @pub.instance_variable_get(:@channels)[@pub.server]
     end
 
+    test "publishers maintain their own set of channels" do
+      @p1 = Publisher.new(@client)
+      @p2 = Publisher.new(@client)
+
+      refute_equal @p1.instance_variable_get(:@channels), @p2.instance_variable_get(:@channels)
+    end
   end
 
   class PublisherPublishingTest < Minitest::Test


### PR DESCRIPTION
This updates the publisher to store channels in  thread local storage.
This is required for multithreaded ruby environments.

If channels are shared across threads, frames might be send out of order (interleaved) to the server.
With this change we store the channels (one per configured server) in a thread local variable, which means each thread has its own set of channels.

Naturally, this will effect the number of open channels to the rabbit server.

## Note to our platform internal users

Our applications run in a multiprocess manner, so this change will not have a visible effect.
It is merely here to make multithreaded use possible (i.e. in tests).
