### PR TITLE
Bunny bug: the routing key is removed on publish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ gemspec
 
 gem "hiredis-client"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
-
-gem "pry", "~> 0.15.2"

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gemspec
 
 gem "hiredis-client"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
+
+gem "pry", "~> 0.15.2"

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -94,7 +94,7 @@ module Beetle
           next if published.include? @server
           bind_queues_for_exchange(exchange_name)
           logger.debug "Beetle: trying to send #{message_name}:#{opts[:message_id]} to #{@server}"
-          exchange(exchange_name).publish(data, opts)
+          exchange(exchange_name).publish(data, opts.dup)
           published << @server
           logger.debug "Beetle: message sent (#{published})!"
         rescue *bunny_exceptions => e

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -2,80 +2,53 @@ require 'pry'
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 class BunnyBehaviorTest < Minitest::Test
-  test "publishing fixnums and hashes works in amqp headers" do
+
+  # test "publishing fixnums and hashes works in amqp headers" do
+  #   client = Beetle::Client.new
+  #   client.register_queue(:test)
+  #   client.register_message(:test)
+  #   # purge the test queue
+  #   client.purge(:test)
+  #   # empty the dedup store
+  #   client.deduplication_store.flushdb
+  #   # register our handler to the message, check out the message.rb for more stuff you can get from the message object
+  #   message = nil
+  #   client.register_handler(:test) {|msg| message = msg; client.stop_listening }
+  #   # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
+  #   published = client.publish(:test, 'bam', headers: { foo: 1, table: {bar: "baz"}})
+  #   # start listening
+  #   client.listen
+  #   client.stop_publishing
+  #   assert_equal 1, published
+  #   assert_equal "bam", message.data
+  #   headers = message.header.attributes[:headers]
+  #   assert_equal 1, headers["foo"]
+  #   assert_equal({"bar" => "baz"}, headers["table"])
+  # end
+
+
+  
+  test "publishing redundantly does not leave the garbage in dedup store" do
+    Beetle.config.servers = "localhost:5672,localhost:5673"
     client = Beetle::Client.new
-    client.register_queue(:test)
-    client.register_message(:test)
-
+    client.register_queue(:test_garbage)
+    client.register_message(:test_garbage)
     # purge the test queue
-    client.purge(:test)
-
+    client.purge(:test_garbage)
     # empty the dedup store
     client.deduplication_store.flushdb
-
     # register our handler to the message, check out the message.rb for more stuff you can get from the message object
     message = nil
-    client.register_handler(:test) {|msg| message = msg; client.stop_listening }
-
+    client.register_handler(:test_garbage) {|msg| message = msg; client.stop_listening }
     # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
-    published = client.publish(:test, 'bam', headers: { foo: 1, table: {bar: "baz"}})
-
+    published = client.publish(:test_garbage, 'bam', :redundant =>true)
     # start listening
     client.listen
     client.stop_publishing
-
-    assert_equal 1, published
-    assert_equal "bam", message.data
-    headers = message.header.attributes[:headers]
-    assert_equal 1, headers["foo"]
-    assert_equal({"bar" => "baz"}, headers["table"])
-  end
-
-  test "publishing redundantly does not leave the garbage in dedup store" do
-    Beetle.config.servers = "localhost:5672,localhost:5673"
-    publisher = Beetle::Client.new
-    publisher.register_message(:test_garbage)
-    publisher.register_queue(:test_garbage)
-    # purge the test queue
-    publisher.purge(:test_garbage)
-    # empty the dedup store
-    publisher.deduplication_store.flushdb
-
-    Beetle.config.servers = "localhost:5672"
-    sub5672 = Beetle::Client.new
-    sub5672.register_queue(:test_garbage)
-
-    Beetle.config.servers = "localhost:5673"
-    sub5673 = Beetle::Client.new
-    sub5673.register_queue(:test_garbage)
-
     
-    message5672 = nil
-    sub5672.register_handler(:test_garbage) {|msg| 
-      binding.pry
-      message5672 = msg; 
-      sub5672.stop_listening 
-      sub5673.stop_listening 
-    }
-
-    message5673 = nil
-    sub5673.register_handler(:test_garbage) {|msg| 
-      binding.pry
-      message5673 = msg; 
-      sub5673.stop_listening 
-    }
-
-    published = publisher.publish(:test_garbage, 'bam', :redundant =>true) 
-
-    sub5672.listen
-    sub5673.listen
-    publisher.stop_publishing
-  
     assert_equal 2, published
-    assert_equal "bam", message5672.data
-    Beetle::DeduplicationStore::KEY_SUFFIXES.map{|suffix| 
-      assert_equal false, publisher.deduplication_store.exists(message5672.msg_id, suffix)
-    }
+    assert_equal "bam", message.data
   end
+
 
 end

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -44,7 +44,9 @@ class BunnyBehaviorTest < Minitest::Test
     listen(client)
     client.stop_publishing
 
-    message = handler.messages_processed.first
+    messages_processed = handler.messages_processed
+    assert_equal 1, messages_processed.length
+    message = messages_processed.first
     assert_equal 2, published
     assert_equal "bam", message.data
     Beetle::DeduplicationStore::KEY_SUFFIXES.each{|suffix| 

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -38,15 +38,10 @@ class BunnyBehaviorTest < Minitest::Test
     client.purge(:test_garbage)
     # empty the dedup store
     client.deduplication_store.flushdb
-    # register our handler to the message, check out the message.rb for more stuff you can get from the message object
-    message = nil
 
-    handler = TestHandler.new(2, client)
+    handler = TestHandler.new(stop_after = 2, client = client)
     client.register_handler(:test_garbage, handler)
-    
-    # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
     published = client.publish(:test_garbage, 'bam', :redundant =>true)
-    # start listening
     listen(client)
     client.stop_publishing
 

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -1,30 +1,31 @@
 require 'pry'
+require 'timeout'
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 class BunnyBehaviorTest < Minitest::Test
 
-  # test "publishing fixnums and hashes works in amqp headers" do
-  #   client = Beetle::Client.new
-  #   client.register_queue(:test)
-  #   client.register_message(:test)
-  #   # purge the test queue
-  #   client.purge(:test)
-  #   # empty the dedup store
-  #   client.deduplication_store.flushdb
-  #   # register our handler to the message, check out the message.rb for more stuff you can get from the message object
-  #   message = nil
-  #   client.register_handler(:test) {|msg| message = msg; client.stop_listening }
-  #   # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
-  #   published = client.publish(:test, 'bam', headers: { foo: 1, table: {bar: "baz"}})
-  #   # start listening
-  #   client.listen
-  #   client.stop_publishing
-  #   assert_equal 1, published
-  #   assert_equal "bam", message.data
-  #   headers = message.header.attributes[:headers]
-  #   assert_equal 1, headers["foo"]
-  #   assert_equal({"bar" => "baz"}, headers["table"])
-  # end
+  test "publishing fixnums and hashes works in amqp headers" do
+    client = Beetle::Client.new
+    client.register_queue(:test)
+    client.register_message(:test)
+    # purge the test queue
+    client.purge(:test)
+    # empty the dedup store
+    client.deduplication_store.flushdb
+    # register our handler to the message, check out the message.rb for more stuff you can get from the message object
+    message = nil
+    client.register_handler(:test) {|msg| message = msg; client.stop_listening }
+    # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
+    published = client.publish(:test, 'bam', headers: { foo: 1, table: {bar: "baz"}})
+    # start listening
+    client.listen
+    client.stop_publishing
+    assert_equal 1, published
+    assert_equal "bam", message.data
+    headers = message.header.attributes[:headers]
+    assert_equal 1, headers["foo"]
+    assert_equal({"bar" => "baz"}, headers["table"])
+  end
 
 
   
@@ -39,15 +40,57 @@ class BunnyBehaviorTest < Minitest::Test
     client.deduplication_store.flushdb
     # register our handler to the message, check out the message.rb for more stuff you can get from the message object
     message = nil
-    client.register_handler(:test_garbage) {|msg| message = msg; client.stop_listening }
+
+    handler = TestHandler.new(2, client)
+    client.register_handler(:test_garbage, handler)
+    
     # publish our message (NOTE: empty message bodies don't work, most likely due to bugs in bunny/amqp)
     published = client.publish(:test_garbage, 'bam', :redundant =>true)
     # start listening
-    client.listen
+    listen(client)
     client.stop_publishing
-    
+
+    message = handler.messages_processed.first
     assert_equal 2, published
     assert_equal "bam", message.data
+    Beetle::DeduplicationStore::KEY_SUFFIXES.map{|suffix| 
+        assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
+    }
+  end
+
+  def listen(client , timeout = 1) 
+    Timeout.timeout(timeout) do 
+      client.listen 
+    end
+  rescue Timeout::Error 
+       puts "Client listen timed out after #{timeout} seconds"
+       nil
+  end
+
+
+  class TestHandler < Beetle::Handler
+
+    attr_reader :messages_processed
+
+    def initialize(stop_after, client)
+      super()
+      @stop_after = stop_after
+      @client = client
+      @invocations = 0
+      @messages_processed = []
+    end
+    
+    def process
+      @messages_processed << message
+    end
+
+    def post_process
+      @invocations += 1
+      if @invocations >= @stop_after
+          @client.stop_listening
+      end
+    end
+
   end
 
 

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -47,7 +47,7 @@ class BunnyBehaviorTest < Minitest::Test
     message = handler.messages_processed.first
     assert_equal 2, published
     assert_equal "bam", message.data
-    Beetle::DeduplicationStore::KEY_SUFFIXES.map{|suffix| 
+    Beetle::DeduplicationStore::KEY_SUFFIXES.each{|suffix| 
         assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
     }
   end

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'timeout'
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -38,7 +38,7 @@ class BunnyBehaviorTest < Minitest::Test
     # empty the dedup store
     client.deduplication_store.flushdb
 
-    handler = TestHandler.new(stop_after = 2, client = client)
+    handler = TestHandler.new(stop_after_n_post_processes = 2, client = client)
     client.register_handler(:test_garbage, handler)
     published = client.publish(:test_garbage, 'bam', :redundant =>true)
     listen(client)
@@ -68,9 +68,9 @@ class BunnyBehaviorTest < Minitest::Test
 
     attr_reader :messages_processed
 
-    def initialize(stop_after, client)
+    def initialize(stop_after_n_post_processes, client)
       super()
-      @stop_after = stop_after
+      @stop_after_n_post_processes = stop_after_n_post_processes
       @client = client
       @invocations = 0
       @messages_processed = []
@@ -82,7 +82,7 @@ class BunnyBehaviorTest < Minitest::Test
 
     def post_process
       @invocations += 1
-      if @invocations >= @stop_after
+      if @invocations >= @stop_after_n_post_processes
           @client.stop_listening
       end
     end

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -77,9 +77,6 @@ class BunnyBehaviorTest < Minitest::Test
     assert_equal "bam", message.data
     assert_equal 2, handler.post_process_invocations
     assert_equal 2, handler.pre_process_invocations
-    Beetle::DeduplicationStore::KEY_SUFFIXES.each{|suffix| 
-        assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
-    }
   end
 
   def listen(client , timeout = 1) 


### PR DESCRIPTION
Add test to cover a bug in the bunny where the routing key is removed on publish.

Ticket:

https://new-work.atlassian.net/browse/APII-2137