### PR TITLE
Fix thread local store for channels

### DIFF
--- a/lib/beetle/channels.rb
+++ b/lib/beetle/channels.rb
@@ -22,20 +22,26 @@ module Beetle
 
     def initialize
       @uuid = SecureRandom.uuid
-      Thread.current[THREAD_LOCAL_KEY] ||= {}
-      Thread.current[THREAD_LOCAL_KEY][@uuid] = {}
     end
 
     def []=(server, channel)
-      Thread.current[THREAD_LOCAL_KEY][@uuid][server] = channel
+      thread_local[server] = channel
     end
 
     def [](server)
-      Thread.current[THREAD_LOCAL_KEY][@uuid][server]
+      thread_local[server]
     end
 
     def cleanup!
+      return unless Thread.current[THREAD_LOCAL_KEY]
+
       Thread.current[THREAD_LOCAL_KEY].delete(@uuid)
+    end
+
+    def thread_local
+      Thread.current[THREAD_LOCAL_KEY] ||= {}
+      Thread.current[THREAD_LOCAL_KEY][@uuid] ||= {}
+      Thread.current[THREAD_LOCAL_KEY][@uuid]
     end
   end
 end

--- a/test/beetle/channels_test.rb
+++ b/test/beetle/channels_test.rb
@@ -26,5 +26,44 @@ module Beetle
       @channels2["key"] = o2
       refute_equal @channels["key"].object_id, @channels2["key"].object_id
     end
+
+    test "different threads get their own state" do
+      @channels = Beetle::Channels.new
+      saw_key = nil
+
+      th1 = Thread.new do
+        @channels["key"] = Object.new
+        sleep 1
+      end
+
+      th2 = Thread.new do
+        saw_key = @channels["key"]
+      end
+
+      [th1, th2].each(&:join)
+
+      assert_nil @channels["key"]
+      refute saw_key
+    end
+
+    test "different threads with different instances get their own state" do
+      @channels = Beetle::Channels.new
+      @channels2 = Beetle::Channels.new
+      o = Object.new
+      saw_o = nil
+      o2 = Object.new
+      saw_o2 = nil
+
+      Thread.new do
+        @channels["key"] = o
+        @channels2["key"] = o2
+        saw_o = @channels["key"]
+        saw_o2 = @channels2["key"]
+      end.join
+
+      assert saw_o
+      assert saw_o2
+      refute_equal saw_o.object_id, saw_o2.object_id
+    end
   end
 end


### PR DESCRIPTION
The storage needs to be lazily initialized for cases where the channels object is created in a different thread than where its used.