### PR TITLE
V5.1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 5.1.0
+* Add publisher confirms
+* Add defensive copying against options mutation when passing to bunny library
+
 ## Version 5.0.1
 * Make channels thread local, to avoid problems with out-of-order amqp frames when the client is shared across threads 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Version 5.1.0
 * Add possibility to enable publisher confirms on a per client basis 
 * [BUGFIX] Add defensive copying against options mutation when passing to bunny library
+* [BUGFIX] Thread local channels don't cause errors when a client is created in a different thread than where its used
 
 ## Version 5.0.1
 * Make channels thread local, to avoid problems with out-of-order amqp frames when the client is shared across threads 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 # Release Notes
 
 ## Version 5.1.0
-* Add publisher confirms
-* Add defensive copying against options mutation when passing to bunny library
+* Add possibility to enable publisher confirms on a per client basis 
+* [BUGFIX] Add defensive copying against options mutation when passing to bunny library
 
 ## Version 5.0.1
 * Make channels thread local, to avoid problems with out-of-order amqp frames when the client is shared across threads 

--- a/lib/beetle/version.rb
+++ b/lib/beetle/version.rb
@@ -1,3 +1,3 @@
 module Beetle
-  VERSION = "5.1.0-rc1  "
+  VERSION = "5.1.0-rc1"
 end

--- a/lib/beetle/version.rb
+++ b/lib/beetle/version.rb
@@ -1,3 +1,3 @@
 module Beetle
-  VERSION = "5.0.1"
+  VERSION = "5.1.0-rc1  "
 end

--- a/lib/beetle/version.rb
+++ b/lib/beetle/version.rb
@@ -1,3 +1,3 @@
 module Beetle
-  VERSION = "5.1.0-rc2"
+  VERSION = "5.1.0"
 end

--- a/lib/beetle/version.rb
+++ b/lib/beetle/version.rb
@@ -1,3 +1,3 @@
 module Beetle
-  VERSION = "5.1.0-rc1"
+  VERSION = "5.1.0-rc2"
 end


### PR DESCRIPTION
This prepares the release of 5.1 which brings two important changes.

## 1. A bugfix for 5.0.1 which broke redundant message sending

The `Exchange#publish` method in bunny has unfortunately been changed (already years ago), to mutate the options argument that can be passed in. In particular it would delete the routing key from the hash. In our case we have code that attempts to publish with the same options to two brokers. This means that the second publish happened without a routing key. The results are unroutable messages as a primary effect but as a secondary affect this leads to message metadata in the deduplication store that will never be cleaned up / removed. In our case this caused quite some trouble, with a couple of secondary effects that came from that.

## 2. Add a possibility to use publisher confirms

We are moving to a solution in which we don't rely on redundant messaging anymore. Instead we want to provide publisher confirms to provide assurance to publishers that a message has been accepted by the broker.
