### PR TITLE
Configure policy default attributes and priority

### DIFF
--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -10,6 +10,9 @@ module Beetle
     # messages to set up queue policies. Whenever a queue is declared in the client, either by publisher or
     # consumer, a message with the queue policy parameters is sent to this exachange. (defaults to <tt>beetle</tt>)
     attr_accessor :beetle_policy_exchange_name
+    # set the priority for queue policies set via policy updates (defaults to <tt>1</tt>)
+    # see also <tt>https://www.rabbitmq.com/docs/policies#priorities<tt>
+    attr_accessor :beetle_policy_priority
     # Name of the policy update queue
     attr_accessor :beetle_policy_updates_queue_name
     # Name of the policy update routing key
@@ -17,6 +20,7 @@ module Beetle
     # set this to whatever your brokers have installed as default policy. For example, if you have installed
     # a policy that makes every queue lazy, it should be set to <tt>{"queue-moode" => "lazy"}</tt>.
     attr_accessor :broker_default_policy
+
     # default logger (defaults to <tt>Logger.new(log_file)</tt>)
     attr_accessor :logger
 
@@ -182,6 +186,7 @@ module Beetle
       self.beetle_policy_exchange_name = "beetle-policies"
       self.beetle_policy_updates_queue_name = "beetle-policy-updates"
       self.beetle_policy_updates_routing_key = "beetle.policy.update"
+      self.beetle_policy_priority = 1
       self.broker_default_policy = {}
 
       self.gc_threshold = 1.hour.to_i

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -17,6 +17,10 @@ module Beetle
     attr_accessor :beetle_policy_updates_queue_name
     # Name of the policy update routing key
     attr_accessor :beetle_policy_updates_routing_key
+    # The default attributes that are the basis for all policies of target queues (not dead letter queues).
+    # More specific attributes will override these. The default attributes are: <tt>{}<tt>
+    # These are raw rabbitmq policy attributes. See the rabbitmq documentation for details.
+    attr_accessor :beetle_policy_default_attributes
     # set this to whatever your brokers have installed as default policy. For example, if you have installed
     # a policy that makes every queue lazy, it should be set to <tt>{"queue-moode" => "lazy"}</tt>.
     attr_accessor :broker_default_policy
@@ -187,6 +191,7 @@ module Beetle
       self.beetle_policy_updates_queue_name = "beetle-policy-updates"
       self.beetle_policy_updates_routing_key = "beetle.policy.update"
       self.beetle_policy_priority = 1
+      self.beetle_policy_default_attributes = {}
       self.broker_default_policy = {}
 
       self.gc_threshold = 1.hour.to_i

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -60,7 +60,7 @@ module Beetle
 
       put_request_body = {
         "pattern" => "^#{queue_name}$",
-        "priority" => 1,
+        "priority" => @config.beetle_policy_priority,
         "apply-to" => "queues",
         "definition" => definition,
       }

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -49,7 +49,7 @@ module Beetle
       request_path = "/api/policies/#{vhost}/#{policy_name}"
 
       # set up queue policy
-      definition = {}
+      definition = @config.beetle_policy_default_attributes || {}
       if options[:dead_lettering]
         definition["dead-letter-routing-key"] = options[:routing_key]
         definition["dead-letter-exchange"] = ""

--- a/test/beetle/queue_properties_test.rb
+++ b/test/beetle/queue_properties_test.rb
@@ -55,6 +55,70 @@ module Beetle
     end
   end
 
+  class ApplyDefaultAttributesTest < Minitest::Test 
+    def setup
+      @server = "localhost:5672"
+      @queue_name = "QUEUE_NAME"
+      @config = Configuration.new
+      @config.logger = Logger.new("/dev/null")
+      @config.beetle_policy_default_attributes = { "max-length" => 8_000_000, "overflow" => "reject-publish" }
+      @queue_properties = QueueProperties.new(@config)
+    end
+
+    test "applies default attributes to the queue" do
+      stub_request(:get, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
+        .with(basic_auth: ['guest', 'guest'])
+        .to_return(:status => 404)
+
+      stub = stub_request(:put, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
+        .with(basic_auth: ['guest', 'guest'])
+        .with(:body => {
+               "pattern" => "^QUEUE_NAME$",
+               "priority" => 1,
+               "apply-to" => "queues",
+               "definition" => {
+                 "max-length" => 8_000_000,
+                "overflow" => "reject-publish",
+                 "queue-mode" => "lazy"
+               }}.to_json)
+        .to_return(:status => 204)
+
+      @queue_properties.set_queue_policy!(@server, @queue_name, lazy: true)
+      assert_requested(stub)
+    end
+  end
+
+  class SetPolicyPriorityTest < Minitest::Test 
+    def setup
+      @server = "localhost:5672"
+      @queue_name = "QUEUE_NAME"
+      @config = Configuration.new
+      @config.logger = Logger.new("/dev/null")
+      @config.beetle_policy_priority = 2
+      @queue_properties = QueueProperties.new(@config)
+    end
+
+    test "applies default attributes to the queue" do
+      stub_request(:get, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
+        .with(basic_auth: ['guest', 'guest'])
+        .to_return(:status => 404)
+
+      stub = stub_request(:put, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
+        .with(basic_auth: ['guest', 'guest'])
+        .with(:body => {
+               "pattern" => "^QUEUE_NAME$",
+               "priority" => 2,
+               "apply-to" => "queues",
+               "definition" => {
+                 "queue-mode" => "lazy"
+               }}.to_json)
+        .to_return(:status => 204)
+
+      @queue_properties.set_queue_policy!(@server, @queue_name, lazy: true)
+      assert_requested(stub)
+    end
+  end
+
   class SetDeadLetterPolicyTest < Minitest::Test
     def setup
       @server = "localhost:5672"
@@ -66,7 +130,7 @@ module Beetle
 
     test "raises exception when queue name wasn't specified" do
       assert_raises ArgumentError do
-        @queue_properties.set_queue_policy!(@server, "")
+        @queue_properties.set_queue_policy!(server: "localhost:5672", queue_name: "QUEUE_NAME")
       end
     end
 


### PR DESCRIPTION
This allows to set (raw) default policy attributes that are always put into the policy definition.
It also allows to set the priority for the queue policy.

Both of these features are required to set policies reliably on AWS AmazonMQ, which applies a default policy to all queues, which defines the max-length and overflow properties.

We want to be able to apply our own policy, which needs to take precedence, but at the same time we want to retain the settings of the default policy. This change allows to merge deadlettering policies and / or queue-mode with those defaults.