### PR TITLE
Queue policy request override

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem "hiredis-client"
+gem "pry"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"

--- a/lib/beetle/base.rb
+++ b/lib/beetle/base.rb
@@ -122,7 +122,8 @@ module Beetle
     end
 
     def queue_type(server_name, queue_name)
-      queue_arguments = @client.queues[queue_name][:arguments] || {}
+      queue_opts = @client.queues[queue_name] || {}
+      queue_arguments = queue_opts[:arguments] || {}
       queue_type = queue_arguments["x-queue-type"] || queue_arguments[:"x-queue-type"]
 
       case queue_type

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -22,6 +22,11 @@ module Beetle
     # Only suypported queue types are <tt>quorum</tt> and <tt>classic</tt>.
     # These are raw rabbitmq policy attributes. See the rabbitmq documentation for details.
     attr_accessor :beetle_policy_default_attributes
+
+    # A hash definining the default queue type for a queue. Queue type must be either "classic" or "quorum". Default value is <tt>{}</tt>.
+    # If a server can't be found in the hash we assume queue type "classic"
+    attr_accessor :broker_default_queue_type
+
     # set this to whatever your brokers have installed as default policy. For example, if you have installed
     # a policy that makes every queue lazy, it should be set to <tt>{"queue-moode" => "lazy"}</tt>.
     attr_accessor :broker_default_policy
@@ -194,6 +199,7 @@ module Beetle
       self.beetle_policy_priority = 1
       self.beetle_policy_default_attributes = { quorum: {}, classic: {} }
       self.broker_default_policy = {}
+      self.broker_default_queue_type = {}
 
       self.gc_threshold = 1.hour.to_i
       self.redis_server = "localhost:6379"

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -17,8 +17,9 @@ module Beetle
     attr_accessor :beetle_policy_updates_queue_name
     # Name of the policy update routing key
     attr_accessor :beetle_policy_updates_routing_key
-    # The default attributes that are the basis for all policies of target queues (not dead letter queues).
-    # More specific attributes will override these. The default attributes are: <tt>{}<tt>
+    # The default attributes that are the basis for all policies of target queues with given queue type.
+    # More specific attributes will override these. The default attributes are: <tt>{ quorum: {}, classic: {} }<tt>
+    # Only suypported queue types are <tt>quorum</tt> and <tt>classic</tt>.
     # These are raw rabbitmq policy attributes. See the rabbitmq documentation for details.
     attr_accessor :beetle_policy_default_attributes
     # set this to whatever your brokers have installed as default policy. For example, if you have installed
@@ -191,7 +192,7 @@ module Beetle
       self.beetle_policy_updates_queue_name = "beetle-policy-updates"
       self.beetle_policy_updates_routing_key = "beetle.policy.update"
       self.beetle_policy_priority = 1
-      self.beetle_policy_default_attributes = {}
+      self.beetle_policy_default_attributes = { quorum: {}, classic: {} }
       self.broker_default_policy = {}
 
       self.gc_threshold = 1.hour.to_i

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -60,14 +60,8 @@ module Beetle
 
       definition["queue-mode"] = "lazy" if options[:lazy]
 
-      apply_to = case queue_type
-                 when :classic
-                   "classic-queues"
-                 when :quorum
-                   "quorum-queues"
-                 else "queues"
-                 end
-
+      # be compatible with on-prem and only explicitly set the queue type for quorum queues
+      apply_to = queue_type == :quorum ? "quorum_queues" : "queues"
       put_request_body = {
         "pattern" => "^#{queue_name}$",
         "priority" => @config.beetle_policy_priority,

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -15,7 +15,7 @@ module Beetle
       CGI.escape(@config.vhost)
     end
 
-    def update_queue_properties!(options, request_overrides = {})
+    def update_queue_properties!(options)
       logger.info "Updating queue properties: #{options.inspect}"
       options = options.symbolize_keys
       server = options[:server]
@@ -29,14 +29,14 @@ module Beetle
       # applied and stay in the dead letter queue forever (or until manually consumed), thus
       # blocking the head of the queue.
       dead_letter_queue_options = policy_options.merge(:routing_key => target_queue, :message_ttl => options[:message_ttl])
-      set_queue_policy!(server, dead_letter_queue_name, dead_letter_queue_options, request_overrides)
+      set_queue_policy!(server, dead_letter_queue_name, dead_letter_queue_options)
       target_queue_options = policy_options.merge(:routing_key => dead_letter_queue_name)
-      set_queue_policy!(server, target_queue, target_queue_options, request_overrides)
+      set_queue_policy!(server, target_queue, target_queue_options)
 
       remove_obsolete_bindings(server, target_queue, options[:bindings]) if options.has_key?(:bindings)
     end
 
-    def set_queue_policy!(server, queue_name, options={}, request_overrides = {})
+    def set_queue_policy!(server, queue_name, options={})
       logger.info "Setting queue policy: #{server}, #{queue_name}, #{options.inspect}"
 
       raise ArgumentError.new("server missing")     if server.blank?

--- a/lib/beetle/queue_properties.rb
+++ b/lib/beetle/queue_properties.rb
@@ -69,7 +69,7 @@ module Beetle
         "definition" => definition,
       }
 
-      logger.debug "Setting queue policy: #{put_request_body.inspect}"
+      logger.info "Setting queue policy: #{put_request_body.inspect}"
 
       is_default_policy = definition == config.broker_default_policy
 

--- a/test/beetle/base_test.rb
+++ b/test/beetle/base_test.rb
@@ -95,7 +95,7 @@ module Beetle
     end
 
     test "publish_policy_options declares the beetle policy updates queue and publishes the options" do
-      options = { :lazy => true, :dead_lettering => true }
+      options = { queue_name: @queue_name, :lazy => true, :dead_lettering => true }
       @bs.logger.stubs(:debug)
       @bs.expects(:queue).with(@client.config.beetle_policy_updates_queue_name)
       exchange = mock("exchange")
@@ -105,11 +105,12 @@ module Beetle
     end
 
     test "publish_policy_options calls the RabbitMQ API if asked to do so" do
-      options = { :lazy => true, :dead_lettering => true }
+      options = { queue_name: @queue_name, :lazy => true, :dead_lettering => true }
       @bs.logger.stubs(:debug)
       @client.config.expects(:update_queue_properties_synchronously).returns(true)
-      @client.expects(:update_queue_properties!).with(options.merge(:server => "localhost:5672"))
+      @client.expects(:update_queue_properties!).with(options.merge(:server => "localhost:5672", queue_type: nil))
       @bs.__send__(:publish_policy_options, options)
     end
+
   end
 end

--- a/test/beetle/queue_properties_test.rb
+++ b/test/beetle/queue_properties_test.rb
@@ -55,39 +55,6 @@ module Beetle
     end
   end
 
-  class OverrideRequestTest < Minitest::Test
-    def setup
-      @server = "localhost:5672"
-      @queue_name = "QUEUE_NAME"
-      @config = Configuration.new
-      @config.logger = Logger.new("/dev/null")
-      @config.beetle_policy_default_attributes = { "max-length" => 8_000_000, "overflow" => "reject-publish" }
-      @queue_properties = QueueProperties.new(@config)
-    end
-
-    test "overrides the request body" do
-      stub_request(:get, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
-        .with(basic_auth: ['guest', 'guest'])
-        .to_return(:status => 404)
-
-      stub = stub_request(:put, "http://localhost:15672/api/policies/%2F/QUEUE_NAME_policy")
-        .with(basic_auth: ['guest', 'guest'])
-        .with(:body => {
-               "pattern" => "^QUEUE_NAME$",
-               "priority" => 1,
-               "apply-to" => "quorum_queues",
-               "definition" => {
-                 "max-length" => 8_000_000,
-                "overflow" => "reject-publish",
-                 "queue-mode" => "lazy"
-               }}.to_json)
-        .to_return(:status => 204)
-
-      @queue_properties.set_queue_policy!(@server, @queue_name, {lazy: true}, "apply-to" => "qorum_queues")
-      assert_requested(stub)
-    end
-  end
-
   class ApplyDefaultAttributesTest < Minitest::Test 
     def setup
       @server = "localhost:5672"
@@ -108,7 +75,7 @@ module Beetle
         .with(:body => {
                "pattern" => "^QUEUE_NAME$",
                "priority" => 1,
-               "apply-to" => "queues",
+               "apply-to" => "quorum_queues",
                "definition" => {
                  "max-length" => 8_000_000,
                 "overflow" => "reject-publish",
@@ -141,7 +108,7 @@ module Beetle
         .with(:body => {
                "pattern" => "^QUEUE_NAME$",
                "priority" => 2,
-               "apply-to" => "queues",
+               "apply-to" => "quorum_queues",
                "definition" => {
                  "queue-mode" => "lazy"
                }}.to_json)


### PR DESCRIPTION
This allows to override the queue policy request that's being made to the server.
It gives us a final place to tweak what's sent.