### PR TITLE
Ruby amqp tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [3.1.6, 3.2.5, 3.3.4]
-        redis-version: [4, 5]
+        redis-version: [6]
         rails-version: [6.1.7.8, 7.0.8.4, 7.1.4, 7.2.1]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.20.7'
-
+          
+      - name: Upgrade Docker Compose
+        uses: docker/setup-compose-action@v1
+        with:
+          version: latest
+          
       - name: Install dependencies
         run: sudo apt-get install redis
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [3.1.6, 3.2.5, 3.3.4]
-        redis-version: [6]
+        redis-version: [4,5]
         rails-version: [6.1.7.8, 7.0.8.4, 7.1.4, 7.2.1]
 
     steps:

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -148,6 +148,15 @@ module Beetle
     # consider this a highly experimental feature for now.
     attr_accessor :publisher_connect_timeout
 
+    # the connect/disconnect timeout in seconds for the subscription connection (defaults to <tt>5</tt>).
+    attr_accessor :subscriber_connect_timeout
+
+    # the delay in seconds between reconnects on connection loss (defaults to <tt>10</tt>)
+    attr_accessor :subscriber_reconnect_delay
+
+    # the heartbeats to use for the subscriber connection (defaults to <tt>false</tt>)
+    attr_accessor :subscriber_heartbeats
+
     # Prefetch count for subscribers (defaults to 1). Setting this higher
     # than 1 can potentially increase throughput, but comes at the cost of
     # decreased parallelism.
@@ -231,6 +240,10 @@ module Beetle
 
       self.publishing_timeout = 5 # seconds
       self.publisher_connect_timeout = 5 # seconds
+
+      self.subscriber_connect_timeout = 5 # seconds
+      self.subscriber_reconnect_delay = 10 # seconds
+      self.subscriber_heartbeats = false
 
       self.automatically_recover = false
       self.max_recovery_attempts = nil

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -154,8 +154,8 @@ module Beetle
     # the delay in seconds between reconnects on connection loss (defaults to <tt>10</tt>)
     attr_accessor :subscriber_reconnect_delay
 
-    # the heartbeats to use for the subscriber connection (defaults to <tt>false</tt>)
-    attr_accessor :subscriber_heartbeats
+    # the heartbeats to use for the subscriber connection (defaults to <tt>0</tt>)
+    attr_accessor :subscriber_heartbeat
 
     # Prefetch count for subscribers (defaults to 1). Setting this higher
     # than 1 can potentially increase throughput, but comes at the cost of
@@ -243,7 +243,7 @@ module Beetle
 
       self.subscriber_connect_timeout = 5 # seconds
       self.subscriber_reconnect_delay = 10 # seconds
-      self.subscriber_heartbeats = false
+      self.subscriber_heartbeat = 0
 
       self.automatically_recover = false
       self.max_recovery_attempts = nil

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -253,6 +253,10 @@ module Beetle
       logger.debug "Beetle: deleted mutex: #{msg_id}"
     end
 
+    def redelivered?
+      header.redelivered?
+    end
+
     def fetch_status_delay_timeout_attempts_exceptions
       @store.mget(msg_id, [:status, :delay, :timeout, :attempts, :exceptions])
     end

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -257,6 +257,15 @@ module Beetle
       header.redelivered?
     end
 
+    def delivery_count
+      return unless header
+
+      cnt = header.attributes['x-delivery-count']
+      return unless cnt
+
+      cnt.to_i
+    end
+
     def fetch_status_delay_timeout_attempts_exceptions
       @store.mget(msg_id, [:status, :delay, :timeout, :attempts, :exceptions])
     end

--- a/lib/beetle/message.rb
+++ b/lib/beetle/message.rb
@@ -258,9 +258,10 @@ module Beetle
     end
 
     def delivery_count
-      return unless header
+      headers = header.attributes[:headers] 
+      return nil unless headers
 
-      cnt = header.attributes['x-delivery-count']
+      cnt = headers['x-delivery-count']
       return unless cnt
 
       cnt.to_i

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -239,6 +239,8 @@ module Beetle
         :vhost => options[:vhost],
         :ssl   => options[:ssl],
         :logging => false,
+        :timeout => @client.config.subscriber_connect_timeout,
+        :heartbeat => @client.config.subscriber_hearbeats,
         :on_tcp_connection_failure => on_tcp_connection_failure,
         :on_possible_authentication_failure => on_possible_authentication_failure,
       }

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -240,7 +240,7 @@ module Beetle
         :ssl   => options[:ssl],
         :logging => false,
         :timeout => @client.config.subscriber_connect_timeout,
-        :heartbeat => @client.config.subscriber_hearbeats,
+        :heartbeat => @client.config.subscriber_heartbeats,
         :on_tcp_connection_failure => on_tcp_connection_failure,
         :on_possible_authentication_failure => on_possible_authentication_failure,
       }

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -248,8 +248,8 @@ module Beetle
 
     def on_tcp_connection_failure
       Proc.new do |settings|
-        logger.warn "Beetle: connection failed: #{server_from_settings(settings)}"
-        EM::Timer.new(10) { connect_server(settings) }
+        logger.warn "Beetle: connection failed: #{server_from_settings(settings)}. Timeout: #{@client.config.subscriber_connect_timeout} seconds. Delay before retry: #{@client.config.subscriber_reconnect_delay} seconds."
+        EM::Timer.new(@client.config.subscriber_reconnect_delay) { connect_server(settings) }
       end
     end
 

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -190,7 +190,7 @@ module Beetle
             logger.debug "Beetle: rejected #{msg_id} RC: #{result.name}"
           elsif reply_to = header.attributes[:reply_to]
             logger.debug "Beetle: sending reply to queue #{reply_to} for #{msg_id}"
-            status = result == Beetle::RC::OK ? "OK" : "FAILED e"
+            status = result == Beetle::RC::OK ? "OK" : "FAILED"
             exchange = AMQP::Exchange.new(channel(server), :direct, "")
             exchange.publish(m.handler_result.to_s, :routing_key => reply_to, :persistent => false, :headers => {:status => status})
           end

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -190,7 +190,7 @@ module Beetle
             logger.debug "Beetle: rejected #{msg_id} RC: #{result.name}"
           elsif reply_to = header.attributes[:reply_to]
             logger.debug "Beetle: sending reply to queue #{reply_to} for #{msg_id}"
-            status = result == Beetle::RC::OK ? "OK" : "FAILED"
+            status = result == Beetle::RC::OK ? "OK" : "FAILED e"
             exchange = AMQP::Exchange.new(channel(server), :direct, "")
             exchange.publish(m.handler_result.to_s, :routing_key => reply_to, :persistent => false, :headers => {:status => status})
           end
@@ -240,7 +240,7 @@ module Beetle
         :ssl   => options[:ssl],
         :logging => false,
         :timeout => @client.config.subscriber_connect_timeout,
-        :heartbeat => @client.config.subscriber_heartbeats,
+        :heartbeat => @client.config.subscriber_heartbeat,
         :on_tcp_connection_failure => on_tcp_connection_failure,
         :on_possible_authentication_failure => on_possible_authentication_failure,
       }

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -13,7 +13,7 @@ module Beetle
     end
 
     test "#delivery_count returns the value of the x-delivery-count header if present" do
-      header = header_with_params({ "x-delivery-count" => 5 })
+      header = header_with_params({ headers: { "x-delivery-count" => 5 } })
       m = Message.new("queue", header, 'foo')
 
       assert_equal 5, m.delivery_count

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -5,11 +5,25 @@ module Beetle
   class RedeliveryInformationTest < Minitest::Test
     test "#redelivered is true if the message has been redelivered" do
       header = header_with_params({})
-      header.subjects(:redelivered?).returns(true)
+      header.stubs(:redelivered?).returns(true)
 
       m = Message.new("queue", header, 'foo')
 
       assert m.redelivered?
+    end
+
+    test "#delivery_count returns the value of the x-delivery-count header if present" do
+      header = header_with_params({ "x-delivery-count" => 5 })
+      m = Message.new("queue", header, 'foo')
+
+      assert_equal 5, m.delivery_count
+    end
+
+    test "#delivery_count returns nil if the x-delivery-count header is not present" do
+      header = header_with_params()
+      m = Message.new("queue", header, 'foo')
+
+      assert_nil m.delivery_count
     end
   end
 

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -2,6 +2,16 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 
 module Beetle
+  class RedeliveryInformationTest < Minitest::Test
+    test "#redelivered is true if the message has been redelivered" do
+      header = header_with_params({})
+      header.subjects(:redelivered?).returns(true)
+
+      m = Message.new("queue", header, 'foo')
+
+      assert m.redelivered?
+    end
+  end
 
   class EncodingTest < Minitest::Test
     test "an exception during decoding should be stored in the exception attribute" do

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -438,7 +438,7 @@ module Beetle
       cb = @sub.send(:on_tcp_connection_failure)
       EM::Timer.expects(:new).with(10).yields
       @sub.expects(:connect_server).with(@settings)
-      @sub.logger.expects(:warn).with("Beetle: connection failed: mickey:42")
+      @sub.logger.expects(:warn).with("Beetle: connection failed: mickey:42. Timeout: 5 seconds. Delay before retry: 10 seconds.")
       cb.call(@settings)
     end
 


### PR DESCRIPTION
This adds options to tweak the subscriber side. In particular it adds configuration for connection timeouts and heartbeats, as well as control over the backoff between reconnects.