### PR TITLE
Expose information about bound queues for exchange

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -15,6 +15,10 @@ module Beetle
       at_exit { stop }
     end
 
+    def queues_for_exchange_declared?(exchange_name)
+      @exchanges_with_bound_queues.include?(exchange_name)
+    end
+
     def throttled?
       @throttled
     end


### PR DESCRIPTION
We need this in xing-amqp to expose span information about the initialization status of queues for a given exchange.