### PR TITLE
Allow to disable lazy queue setup

### DIFF
--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -170,6 +170,7 @@ module Beetle
 
     # enable auto recovery with bunny on network failures (defaults to <tt>false</tt>)
     attr_accessor :automatically_recover
+
     # how often should bunny try to recover from a network failure. nil means forever (defaults to <tt>nil</tt>)
     attr_accessor :max_recovery_attempts
 
@@ -178,6 +179,10 @@ module Beetle
 
     # enable publisher confirms (defaults to <tt>false</tt>)
     attr_accessor :publisher_confirms
+
+    # enable lazy queue setup (defaults to <tt>true</tt>)
+    # this means that on first publish to an exchange we declare all the queues that are bound to it
+    attr_accessor :publisher_lazy_queue_setup
 
     # returns the configured amqp brokers
     def brokers
@@ -250,6 +255,7 @@ module Beetle
       self.log_file = STDOUT
 
       self.publisher_confirms = false
+      self.publisher_lazy_queue_setup = true
     end
 
     # setting the external config file will load it on assignment

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -259,6 +259,11 @@ module Beetle
     end
 
     def bind_queues_for_exchange(exchange_name)
+      unless @client.config.publisher_lazy_queue_setup
+        logger.debug "Lazy queue setup is disabled. Will not bind queues for exchange #{exchange_name}."
+        return
+      end
+
       return if @exchanges_with_bound_queues.include?(exchange_name)
       @client.exchanges[exchange_name][:queues].each {|q| queue(q) }
       @exchanges_with_bound_queues[exchange_name] = true


### PR DESCRIPTION
This allows to disable the binding of queues for exchanges, on first publish to an exchange.

The declaration of those queues can be costly as it involves communication with the broker.

If you want to disable this you can optimize the effect, but on the flip-side you have to make sure that queues are bound on the server before. You can use `Client#setup_queues_and_policies` to do that.