### PR TITLE
Add custom error handler for bunny session

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.3.8, 3.4.1]
+        ruby-version: [3.3.8, 3.4.1, 3.4.4]
         redis-version: [7]
         rails-version: [7.0.8.4, 7.1.4, 7.2.1, 8.0.2]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,10 @@ jobs:
       - name: Install gems and run beetle gem tests
         run: bundle install && bundle exec rake test
         env:
-          #BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
           MINITEST_REPORTER: SpecReporter
 
       - name: Run beetle failover tests
         run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
-        #env:
-          #BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
 
       - name: Collect Docker Logs
         uses: jwalton/gh-docker-logs@v2.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.1.6, 3.2.5, 3.3.4]
+        ruby-version: [3.3.8, 3.4.1, 3.4.4]
         redis-version: [4,5]
-        rails-version: [6.1.7.8, 7.0.8.4, 7.1.4, 7.2.1]
+        rails-version: [7.0.8.4, 7.1.4, 7.2.1, 8.0.2]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,13 @@ jobs:
       - name: Install gems and run beetle gem tests
         run: bundle install && bundle exec rake test
         env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
+          #BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
           MINITEST_REPORTER: SpecReporter
 
       - name: Run beetle failover tests
         run: bundle exec cucumber --fail-fast || (tail -n 100 tmp/*.{log,output}; false)
-        env:
-          BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
+        #env:
+          #BUNDLE_GEMFILE: gemfiles/redis_${{ matrix.redis-version }}_rails_${{ matrix.rails-version }}.gemfile
 
       - name: Collect Docker Logs
         uses: jwalton/gh-docker-logs@v2.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.3.8, 3.4.1, 3.4.4]
+        ruby-version: [3.3.8, 3.4.1]
         redis-version: [7]
         rails-version: [7.0.8.4, 7.1.4, 7.2.1, 8.0.2]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [3.3.8, 3.4.1, 3.4.4]
-        redis-version: [4,5]
+        redis-version: [7]
         rails-version: [7.0.8.4, 7.1.4, 7.2.1, 8.0.2]
 
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem "hiredis-client"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem "hiredis-client"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
 gem 'pry'
+gem 'toxiproxy'

--- a/beetle.gemspec
+++ b/beetle.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",           ">= 2.3.4"
 
   s.add_development_dependency "activerecord",        ">= 6.1"
-  s.add_development_dependency "cucumber",            "~> 8.0.0"
+  s.add_development_dependency "cucumber",            "~> 10.0.0"
   s.add_development_dependency "daemon_controller",   "~> 1.2.0"
   s.add_development_dependency "daemons",             ">= 1.2.0"
   s.add_development_dependency "i18n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,16 @@ services:
       - "5673:5672"
       - "15673:15672"
 
+  toxiproxy:
+    container_name: beetle-toxiproxy
+    image: shopify/toxiproxy
+    ports:
+      - "8474:8474"   # HTTP API
+      - "5674:5674"   # rabbit1 
+      - "15674:15674"   # rabbit1-api
+      - "5675:5675"   # rabbit2 
+      - "15675:15675"   # rabbit2-api
+
   consul:
     container_name: beetle-consul
     image: consul:1.7.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   toxiproxy:
     container_name: beetle-toxiproxy
-    image: shopify/toxiproxy
+    image: ghcr.io/shopify/toxiproxy:2.12.0
     ports:
       - "8474:8474"   # HTTP API
       - "5674:5674"   # rabbit1 

--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -30,6 +30,16 @@ module Beetle
   # raised when no message could be sent by the publisher
   class NoMessageSent < Error; end
 
+  class PublisherConnectError < Error
+    attr_reader :server, :cause
+
+    def initialize(server, cause = nil)
+      @server = server
+      @cause = cause
+      super("Publisher failed to connect to server #{server}#{": #{cause.message}" if cause}")
+    end
+  end
+
   class PublisherShutdownError < Error
     attr_reader :errors, :server
 

--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -29,6 +29,17 @@ module Beetle
   class NoRedisMaster < Error; end
   # raised when no message could be sent by the publisher
   class NoMessageSent < Error; end
+
+  class PublisherShutdownError < Error
+    attr_reader :errors, :server
+
+    def initialize(server, errors = [])
+      @errors = errors
+      @server = server
+      super("Publisher failed to shutdown bunny for server #{@server}: #{errors.join(', ')}")
+    end
+  end
+
   # logged when an RPC call timed outdated
   class RPCTimedOut < Error; end
 

--- a/lib/beetle.rb
+++ b/lib/beetle.rb
@@ -36,7 +36,7 @@ module Beetle
     def initialize(server, errors = [])
       @errors = errors
       @server = server
-      super("Publisher failed to shutdown bunny for server #{@server}: #{errors.join(', ')}")
+      super("Publisher failed to shutdown bunny for server #{server}: #{errors.join(', ')}")
     end
   end
 

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -43,18 +43,6 @@ module Beetle
       @throttled ? 'throttled' : 'unthrottled'
     end
 
-    def recoverable_exceptions
-      [
-        AMQ::Protocol::Error,
-        Bunny::Exception, 
-        Errno::EHOSTUNREACH, 
-        Errno::ECONNRESET, 
-        Errno::ETIMEDOUT, 
-        Timeout::Error,
-        Beetle::PublisherConnectError
-      ]
-    end
-
     def publisher_confirms?
       @client.config.publisher_confirms
     end
@@ -207,6 +195,18 @@ module Beetle
     end
 
     private
+
+    def recoverable_exceptions
+      @recoverable_exceptions ||= [
+        AMQ::Protocol::Error,
+        Bunny::Exception, 
+        Errno::EHOSTUNREACH, 
+        Errno::ECONNRESET, 
+        Errno::ETIMEDOUT, 
+        Timeout::Error,
+        Beetle::PublisherConnectError
+      ]
+    end
 
     def bunny
       @bunnies[@server] ||= new_bunny

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -349,7 +349,6 @@ module Beetle
 
     def stop!(_exception=nil)
       return unless bunny?
-
       stop_bunny_forcefully!
     rescue Exception => e
       logger.error "Beetle: error closing down bunny. Publisher process might be in inconsistent state: #{e}"
@@ -369,7 +368,7 @@ module Beetle
     end
 
     def stop_bunny_forcefully!
-      logger.debug "Beetle: closing connection from publisher to #{server} forcefully"
+      logger.debug "Beetle: closing connection from publisher to #{@server} forcefully"
 
       # kill heartbeat sender if it exists
       begin

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -268,13 +268,12 @@ module Beetle
         :session_error_handler => error_handler
       )
 
-      error_handler.synchronize_errors do
-        b.start 
-      end
-
+      b.start 
       b
-    rescue Exception => e
+    rescue StandardError => e
+      # make sure we let the error handler linger around 
       @bunny_error_handlers[@server] = nil
+
       raise e
     end
 
@@ -289,7 +288,7 @@ module Beetle
     end
 
     def log_publishing_exception(exception:, tries:, server:, message_name:, exchange_name:)
-      logger.warn("Beetle: publishing exception server=#{@server} tries=#{tries} message_name=#{message_name} exchange_name=#{exchange_name} exception=#{exception} backtrace=#{exception.backtrace[0..16].join("\n")}")
+      logger.warn("Beetle: publishing exception server=#{server} tries=#{tries} message_name=#{message_name} exchange_name=#{exchange_name} exception=#{exception} backtrace=#{exception.backtrace[0..16].join("\n")}")
     end
 
     # retry dead servers after ignoring them for 10.seconds

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -17,10 +17,6 @@ module Beetle
       at_exit { stop }
     end
 
-    def logger
-      @client.config.logger || Beetle.config.logger
-    end
-
     def exceptions?
       @bunny_error_handlers.any? do |_, error_handler|
         error_handler&.exception?

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -41,7 +41,7 @@ module Beetle
 
     def bunny_exceptions
       [
-        AMQ::Protocol::EmptyResponseError, # QUESTION: should we handle all of AMQ::Protocol::Error instead? 
+        AMQ::Protocol::Error,
         Bunny::Exception, 
         Errno::EHOSTUNREACH, 
         Errno::ECONNRESET, 

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -402,6 +402,7 @@ module Beetle
         end
       rescue StandardError => e
         partial_failures << e
+        logger.warn "Beetle: error closing connection to server: #{e}"
       end
 
       return if partial_failures.empty?

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -9,6 +9,7 @@ module Beetle
       @error_args = nil
 
       @reraise_errors = false
+      # TODO: think through if we need this mutex
       @reraise_mutex = Mutex.new
       @logger = logger
     end

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -203,7 +203,6 @@ module Beetle
         :password              => options[:pass],
         :vhost                 => options[:vhost],
         :tls                   => options[:ssl] || false,
-        :automatically_recover => false,
         :logger                => @client.config.logger,
         :frame_max             => @client.config.frame_max,
         :channel_max           => @client.config.channel_max,
@@ -211,7 +210,12 @@ module Beetle
         :write_timeout         => @client.config.publishing_timeout,
         :continuation_timeout  => @client.config.publishing_timeout * 1000, # continuation timeout is in milliseconds while the other timeouts are in seconds :/
         :connection_timeout    => @client.config.publisher_connect_timeout,
-        :heartbeat             => @client.config.heartbeat
+        :heartbeat             => @client.config.heartbeat,
+
+        # make sure auto recovery is actually deactived
+        :automatically_recover => false, # normal network errors are not recovered
+        :recover_from_connection_close => false, # force close from server are not recovered 
+        :network_recovery_interval => 0 # bunny is buggy and still has code paths that use this even when recovery is disabled, so we set it to 0
       )
       b.start
       b

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -70,17 +70,6 @@ module Beetle
       end
     end
 
-    def synchronize_bunny_errors!(&block)
-      error_handler = bunny_error_handler
-
-      if error_handler
-        error_handler.synchronize_errors(&block)
-      else
-        logger.error "Beetle: no session error handler for server #{@server} found. This should not happen."
-        block.call
-      end
-    end
-
     def publish_with_failover(exchange_name, message_name, data, opts) #:nodoc:
       tries = @servers.size * 2
       logger.debug "Beetle: sending #{message_name}"

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -75,7 +75,7 @@ module Beetle
       if error_handler
         error_handler.synchronize_errors(&block)
       else
-        logger.error "Beetle: no session error handler for server #{server} found. This should not happen."
+        logger.error "Beetle: no session error handler for server #{@server} found. This should not happen."
         block.call
       end
     end

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -271,7 +271,9 @@ module Beetle
       error_handler.synchronize_errors do
         b.start 
       end
-    rescue StandardError => e
+
+      b
+    rescue Exception => e
       @bunny_error_handlers[@server] = nil
       raise e
     end

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -235,7 +235,7 @@ module Beetle
 
       # The order of creating the error handler and the Bunny instance is important.
       # The error handler has exist and it has to be assigned before we start the bunny connection.
-      error_handler = PublisherSessionErrorHandler.new(logger, self, @server)
+      error_handler = PublisherSessionErrorHandler.new(logger, @server)
       @bunny_error_handlers[@server] = error_handler
 
       b = Bunny.new(

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -367,12 +367,6 @@ module Beetle
       @queues[@server] = {}
     end
 
-    def with_publishing_timeout(&block)
-      timeout = @client.config.publishing_timeout + @client.config.publisher_connect_timeout + 1
-
-      Beetle::Timer.timeout(timeout, &block)
-    end
-
     def stop_bunny_forcefully!(exception = nil) 
       logger.debug "Beetle: closing connection from publisher to #{@server} forcefully (exception: #{exception})"
 
@@ -399,9 +393,7 @@ module Beetle
       # it's fine that we don't have a reader loop here anymore, since we don't expect
       # an answer from the server
       begin
-        with_publishing_timeout do
-          bunny.__send__ :close_connection, false
-        end
+        bunny.__send__ :close_connection, false
       rescue StandardError => e
         partial_failures << e
         logger.warn "Beetle: error closing connection to server: #{e}"

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -41,7 +41,7 @@ module Beetle
 
     def bunny_exceptions
       [
-        AMQ::Protocol::EmptyResponseError,
+        AMQ::Protocol::EmptyResponseError, # QUESTION: should we handle all of AMQ::Protocol::Error instead? 
         Bunny::Exception, 
         Errno::EHOSTUNREACH, 
         Errno::ECONNRESET, 

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -227,7 +227,7 @@ module Beetle
     end
 
     def bunny_error_handler?
-      !!@bunny_error_handlers[@server]
+      !!bunny_error_handler
     end
 
     def new_bunny

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -224,7 +224,7 @@ module Beetle
     end
 
     def stop_on_bunny_error!
-      bunny_error_handler&.raise_pending_error! 
+      bunny_error_handler&.raise_pending_exception! 
     rescue StandardError => e
       stop!(e)
     end

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -39,10 +39,14 @@ module Beetle
       @throttled ? 'throttled' : 'unthrottled'
     end
 
-    # List of exceptions potentially raised by bunny.
     def bunny_exceptions
       [
-        Bunny::Exception, Errno::EHOSTUNREACH, Errno::ECONNRESET, Errno::ETIMEDOUT, Timeout::Error
+        AMQ::Protocol::EmptyResponseError,
+        Bunny::Exception, 
+        Errno::EHOSTUNREACH, 
+        Errno::ECONNRESET, 
+        Errno::ETIMEDOUT, 
+        Timeout::Error
       ]
     end
 

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -347,7 +347,7 @@ module Beetle
       queue.bind(exchange(exchange_name), binding_options.dup)
     end
 
-    def stop!(_exception=nil)
+    def stop!
       return unless bunny?
       stop_bunny_forcefully!
     rescue Exception => e

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -271,7 +271,7 @@ module Beetle
       b.start 
       b
     rescue StandardError => e
-      # make sure we let the error handler linger around 
+      # make sure we let no error handler linger around 
       @bunny_error_handlers[@server] = nil
 
       raise e

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -17,6 +17,10 @@ module Beetle
       at_exit { stop }
     end
 
+    def logger
+      @client.config.logger || Beetle.config.logger
+    end
+
     def exceptions?
       @bunny_error_handlers.any? do |_, error_handler|
         error_handler&.exception?

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -347,9 +347,9 @@ module Beetle
       queue.bind(exchange(exchange_name), binding_options.dup)
     end
 
-    def stop!
+    def stop!(exception = nil) #:nodoc:
       return unless bunny?
-      stop_bunny_forcefully!
+      stop_bunny_forcefully!(exception) 
     rescue Exception => e
       logger.error "Beetle: error closing down bunny. Publisher process might be in inconsistent state: #{e}"
       Beetle::reraise_expectation_errors!
@@ -367,8 +367,8 @@ module Beetle
       Beetle::Timer.timeout(timeout, &block)
     end
 
-    def stop_bunny_forcefully!
-      logger.debug "Beetle: closing connection from publisher to #{@server} forcefully"
+    def stop_bunny_forcefully!(exception = nil) 
+      logger.debug "Beetle: closing connection from publisher to #{@server} forcefully (exception: #{exception})"
 
       # kill heartbeat sender if it exists
       begin

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -56,6 +56,7 @@ module Beetle
     #    while `block` is executing.
     #
     # This method is not thread-safe, so it should only be called from the same thread that has a reference to this error handler.
+    # In fact we will enforce this, by raising a `SynchronizationError` if this method is called where its not allowed.
     #
     # Example usage:
     #

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -1,127 +1,70 @@
 module Beetle
-  # A bunny session error handler that handles errors occuring in background threads of bunny
+  # A bunny session error handler detects failures originating from background threads, that belong to a bunny connection.
+  # Using this instead of the default `Thread.current` prevents hard to manage asynchronous exceptions.
   class PublisherSessionErrorHandler
     attr_reader :server
-
-    # An error that is raised when `synchronize_errors` is called in an unsupported context.
-    class SynchronizationError < StandardError; end
 
     # @param logger [Logger] a logger to log errors to
     # @param server_name [String] the name of the server this error handler is bound to
     # @param terminate_thread [Boolean] whether the thread that raised the error should be terminated. Defaults to true.
-    def initialize(logger, server_name, terminate_thread: true)
+    def initialize(logger, server_name, terminate_thread_on_raise: true)
       # the thread which has a reference to the session and this error handler
       @session_thread = Thread.current
 
       @server = server_name
       @logger = logger
-      @terminate_thread = terminate_thread # shall threads be terminated when raise is invoked?
-
-      @synchronous_errors = false
-      @synchronous_errors_mutex = Mutex.new
+      @terminate_thread_on_raise = terminate_thread_on_raise # shall threads be terminated when raise is invoked?
 
       @error_mutex = Mutex.new
       @error_args = nil
     end
 
-    def exceptions?
-      @error_mutex.synchronize { !@error_args.nil? }
+    # Predicate to check if the error handler has detected an error.
+    #
+    # @return [Boolean] true if an error has been recorded, false otherwise
+    def exception?
+      @error_mutex.synchronize { !!@error_args }
     end
 
-    def synchronous_errors?
-      @synchronous_errors_mutex.synchronize { @synchronous_errors }
+    # Resets the error state of this error handler.
+    #
+    # @return [Array, nil] the error arguments that were previously recorded, or nil if no error was recorded
+    def clear_exception!
+      @error_mutex.synchronize do
+        error_args = @error_args
+        @error_args = nil
+        error_args
+      end
     end
 
-    # Raise is called when a bunny component wants to signal an error
-    # This method will mostly be called from a background thread of bunny (reader_loop, heartbeat_sender).
+    def raise_pending_error!
+      error = clear_exception!
+      Kernel.raise(*error) if error
+    end
+
+    # Raise is called when a bunny component wants to signal an error.
+    # It will mostly be called from a background thread of bunny (reader_loop, heartbeat_sender).
     #
-    # The logic of this method depends on when it is invoked.
-    #
-    # If it is invoked in the context of `synchronize_errors`, it will raise the error in the thread that is bound to `@session_thread`
-    # If it is invoked outside of `synchronize_errors`, it will record the error and potentially kill the thread that called this method.
+    # It will do the following:
+    # 1. Record the error arguments, so that they can be raised later
+    # 2. If thread termination is activated, it will terminate the thread that called this method, unless it is the session thread.
     #
     # @param args [Array] the arguments to raise, usually an exception class and a message
     def raise(*args)
       source_thread = Thread.current # the thread that invoked this method
-      is_synchronous = synchronous_errors?
-
-      @logger.error "Beetle: bunny session handler error. server=#{@server} reraise=#{is_synchronous} raised_in=#{source_thread.inspect}."
-
-      reraise!(*args) if is_synchronous
+      @logger.error "Beetle: bunny session handler error. server=#{@server} raised_from=#{source_thread.inspect}."
       record_and_terminate_thread!(source_thread, *args)
-    end
-
-    # This is the main method to surface exceptions that might occur in another thread to the thread that runs this method.
-    # Make sure that you wrap this with error handling code, that can deal with all errors that might have been signaled to the error handler.
-    #
-    # The error semantics are as follows:
-    #
-    # 1. If the error handler has recorded an error, it will raise the first recorded error in the thread that calls the method
-    # 2. If no error has been recorded before, it will execute `block` and reraise all exceptions (including those coming from background threads)
-    #    while `block` is executing.
-    #
-    # This method is not reentrant and not thread-safe, so it should only be called from the same thread that has a reference to this error handler.
-    # In fact we will enforce this, by raising a `SynchronizationError` if this method is called where its not allowed.
-    #
-    # Example usage:
-    #
-    # ```ruby
-    #
-    # begin
-    #   my_error_handler.synchronize_errors do
-    #     # run code that uses the bunny session
-    #   end
-    # rescue Bunny::Exception => e
-    #   # Handle all errors, those in Thread.current but also those that were raised in background threads.
-    #   puts "Bunny error: #{e.message}"
-    # end
-    #
-    # ```
-    def synchronize_errors
-      # both of these will exit early without changing the state @synchronous_errors
-      # so that we make sure a nested call is fine
-      Kernel.raise SynchronizationError, "synchronize_errors must be called from the thread that created the error handler." unless Thread.current == @session_thread
-      Kernel.raise SynchronizationError, "synchronize_errors cannot be nested / re-entered" if synchronous_errors?
-
-      begin
-        @synchronous_errors_mutex.synchronize do
-          @synchronous_errors = true
-        end
-
-        raise_pending_error!
-        yield if block_given?
-      ensure
-        @synchronous_errors_mutex.synchronize do
-          @synchronous_errors = false
-        end
-      end
     end
 
     private
 
-    # safes the first recorded error since it is closes to be the root cause
-    # kill the thread that called this method, unless it is the session thread
     def record_and_terminate_thread!(source_thread, *args)
       @error_mutex.synchronize { @error_args ||= args }
 
-      return unless @terminate_thread
+      return unless @terminate_thread_on_raise
       return if source_thread == @session_thread
 
       source_thread.kill
-    end
-
-    def raise_pending_error!
-      error = @error_mutex.synchronize do
-        err = @error_args
-        @error_args = nil
-        err
-      end
-
-      reraise!(*error) if error
-    end
-
-    def reraise!(*args)
-      @session_thread.raise(*args)
     end
   end
 end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -37,7 +37,7 @@ module Beetle
       end
     end
 
-    def raise_pending_error!
+    def raise_pending_exception!
       error = clear_exception!
       Kernel.raise(*error) if error
     end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -4,19 +4,19 @@ module Beetle
     attr_reader :server, :reraise_target
 
     def initialize(logger, publisher, server_name, session_thread = Thread.current)
+      @publisher = publisher
+      @server = server_name
+      @logger = logger
+
       # the thread which has a reference to the session and this error handler
       @session_thread = session_thread
 
       # the thread in which the error will be raised if re-reaise is enabled
       @reraise_target = nil
-      @publisher = publisher
-      @server = server_name
+      @reraise_errors = false
 
       @error_mutex = Mutex.new
       @error_args = nil
-
-      @reraise_errors = false
-      @logger = logger
     end
 
     def exceptions?

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -97,7 +97,7 @@ module Beetle
         err
       end
 
-      Kernel.raise(*error) if error
+      deliver_to_reraise_target!(*error) if error
     end
   end
 end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -38,7 +38,7 @@ module Beetle
     # @param args [Array] the arguments to raise, usually an exception class and a message
     def raise(*args)
       current_thread = Thread.current
-      @logger.error "Beetle: bunny session handler errror. server=#{@server} reraise=#{@reraise_errors} raised_in=#{current_thread.inspect}."
+      @logger.error "Beetle: bunny session handler error. server=#{@server} reraise=#{@reraise_errors} raised_in=#{current_thread.inspect}."
 
       deliver_to_reraise_target!(*args)
       record_and_terminate_thread!(current_thread, *args)

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -1,9 +1,14 @@
 module Beetle
   # A bunny session error handler that handles errors occuring in background threads of bunny
   class PublisherSessionErrorHandler
-    def initialize(logger, publisher, server_name)
-      @creating_thread = Thread.current
-      @raise_in = nil
+    attr_reader :server, :reraise_target
+
+    def initialize(logger, publisher, server_name, session_thread = Thread.current)
+      # the thread which has a reference to the session and this error handler
+      @session_thread = session_thread
+
+      # the thread in which the error will be raised if re-reaise is enabled
+      @reraise_target = nil
       @publisher = publisher
       @server = server_name
 
@@ -15,54 +20,84 @@ module Beetle
     end
 
     def exceptions?
-      @error_args != nil
+      @error_mutex.synchronize { !@error_args.nil? }
     end
 
-    # Accepts an exception
-    # If this method is called when code is executed ins inside #reraising_errors block
-    # then the exception will be through in the same thread that the block runs.
-    # If this method is called outside of the #rereaising_errors block then the error is recoreded
-    # and will be through the next time #reraising_errors is called.
+    def reraise_errors?
+      @reraise_errors
+    end
+
+    # Raise is called when a bunny component wants to signal an error
+    # This method will mostly be called from a background thread of bunny.
+    # The logic of this method depends on the value of @reraise_errors.
+    # If @reraise_errors is true, the error will be raised in the thread that is bound to @reraise_target.
+    # @reraise_target is set when the session error handler is used in a block that calls `synchronize_errors`.
     #
-    # This essentially delays the raise of excpeptions in the main thread until the code that is prepared to handle them is executed.
+    # In effect, unless @reraise_errors is true, this will delay throwing of the error until the next call to `synchronize_errors`.
+    #
+    # @param args [Array] the arguments to raise, usually an exception class and a message
     def raise(*args)
       current_thread = Thread.current
       @logger.error "Beetle: bunny session handler errror. server=#{@server} reraise=#{@reraise_errors} raised_in=#{current_thread.inspect}."
 
-      # reraise in thread that created the session?
-      @raise_in.raise(*args) if @reraise_errors && @raise_in
-
-      # don't reraise but record
-      @error_mutex.synchronize { @error_args = args }
-
-      # finally schedule the thread that caused the exception for termination
-      current_thread.kill if current_thread != @creating_thread
+      deliver_to_reraise_target!(*args)
+      record_and_terminate_thread!(current_thread, *args)
     end
 
-    # Executes block which has to be prepared to handle errors from this session error handler
-    # If the error handler has an exeption recorded it will be raised before the block is called
-    # If the error handler does not have an exception recorded it will execute block, and every exception handled during execution
-    # of the block, including those raised from another thread, will be re-raised here.
-    def reraising_errors(&block)
-      reraise_last_error!
+    # This is the main method to surface exceptions that might occur in another thread to the thread that runs this method.
+    # Make sure that you wrap this with error handling code, that can deal with all errors that might have been signaled to the error handler.
+    #
+    # The error semantics are as follows:
+    #
+    # 1. If the error handler has recorded an error, it will raise the last recorded error in `Thread.current`
+    # 2. If no error has been recorded before, it will execute `block` and reraise all exceptions (including those coming from background threads)
+    #    while `block` is executing.
+    #
+    # This method is not thread-safe, so it should only be called from the same thread that has a reference to this error handler.
+    #
+    # Example usage:
+    #
+    # ```ruby
+    #
+    # begin
+    #   my_error_handler.synchronize_errors do
+    #     # run publishing code
+    #   end
+    # rescue Bunny::Exception => e
+    #   # Handle all errors, those in Thread.current but also those that were raised in background threads.
+    #   puts "Bunny error: #{e.message}"
+    # end
+    #
+    # ```
+    def synchronize_errors
       @reraise_errors = true
-      @raise_in = Thread.current
-      block.call
+      @reraise_target = Thread.current
+      flush_pending_errors!
+      yield if block_given?
     ensure
       @reraise_errors = false
-      @raise_in = nil
+      @reraise_target = nil
     end
 
     private
 
-    def reraise_last_error!
-      return unless @error_args
-
-      error = @error_args
-      @error_mutex.synchronize { @error_args = nil }
-
-      Kernel.raise(*error)
+    def deliver_to_reraise_target!(*args)
+      @reraise_target.raise(*args) if @reraise_errors && @reraise_target
     end
 
+    def record_and_terminate_thread!(thread, *args)
+      @error_mutex.synchronize { @error_args = args }
+      thread.kill if thread != @session_thread
+    end
+
+    def flush_pending_errors!
+      error = @error_mutex.synchronize do
+        err = @error_args
+        @error_args = nil
+        err
+      end
+
+      Kernel.raise(*error) if error
+    end
   end
 end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -40,20 +40,10 @@ module Beetle
     # Raise is called when a bunny component wants to signal an error.
     # It will mostly be called from a background thread of bunny (reader_loop, heartbeat_sender).
     #
-    # It will do the following:
-    # 1. Record the error arguments, so that they can be raised later
-    # 2. If thread termination is activated, it will terminate the thread that called this method, unless it is the session thread.
-    #
     # @param args [Array] the arguments to raise, usually an exception class and a message
     def raise(*args)
       source_thread = Thread.current # the thread that invoked this method
       @logger.error "Beetle: bunny session handler error. server=#{@server} raised_from=#{source_thread.inspect}."
-      record_and_terminate_thread!(*args)
-    end
-
-    private
-
-    def record_and_terminate_thread!(*args)
       @error_mutex.synchronize { @error_args ||= args }
     end
   end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -2,6 +2,7 @@ module Beetle
   # A bunny session error handler that handles errors occuring in background threads of bunny
   class PublisherSessionErrorHandler
     def initialize(logger, publisher, server_name)
+      @creating_thread = Thread.current
       @raise_in = nil
       @publisher = publisher
       @server = server_name

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -1,0 +1,61 @@
+module Beetle
+  # A bunny session error handler that handles errors occuring in background threads of bunny
+  class PublisherSessionErrorHandler
+    def initialize(logger, publisher, server_name)
+      @publisher = publisher
+      @server = server_name
+
+      @error_mutex = Mutex.new
+      @error_args = nil
+
+      @reraise_errors = false
+      @logger = logger
+    end
+
+    def exceptions?
+      @error_args != nil
+    end
+
+    # Accepts an exception
+    # If this method is called when code is executed ins inside #reraising_errors block
+    # then the exception will be through in the same thread that the block runs.
+    # If this method is called outside of the #rereaising_errors block then the error is recoreded
+    # and will be through the next time #reraising_errors is called.
+    #
+    # This essentially delays the raise of excpeptions in the main thread until the code that is prepared to handle them is executed.
+    def raise(*args)
+      current_thread = Thread.current
+      @logger.error "Beetle: bunny session handler errror. server=#{@server} reraise=#{@reraise_errors}  raised_in=#{current_thread.inspect}."
+
+      # reraise in thread that created the session?
+      Kernel.raise(*args) if @reraise_errors
+
+      # don't reraise but record
+      @error_mutex.synchronize { @error_args = args }
+    end
+
+    # Executes block which has to be prepared to handle errors from this session error handler
+    # If the error handler has an exeption recorded it will be raised before the block is called
+    # If the error handler does not have an exception recorded it will execute block, and every exception handled during execution
+    # of the block, including those raised from another thread, will be re-raised here.
+    def reraising_errors(&block)
+      reraise_last_error!
+      @reraise_errors = true
+      block.call
+    ensure
+      @reraise_errors = false
+    end
+
+    private
+
+    def reraise_last_error!
+      return unless @error_args
+
+      error = @error_args
+      @error_mutex.synchronize { @error_args = nil }
+
+      Kernel.raise(*error)
+    end
+
+  end
+end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -45,6 +45,7 @@ module Beetle
       source_thread = Thread.current # the thread that invoked this method
       @logger.error "Beetle: bunny session handler error. server=#{@server} raised_from=#{source_thread.inspect}."
       @error_mutex.synchronize { @error_args ||= args }
+      nil
     end
   end
 end

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -28,12 +28,12 @@ module Beetle
     end
 
     # Raise is called when a bunny component wants to signal an error
-    # This method will mostly be called from a background thread of bunny.
-    # The logic of this method depends on the value of @reraise_errors.
-    # If @reraise_errors is true, the error will be raised in the thread that is bound to @reraise_target.
-    # @reraise_target is set when the session error handler is used in a block that calls `synchronize_errors`.
+    # This method will mostly be called from a background thread of bunny (reader_loop, heartbeat_sender).
     #
-    # In effect, unless @reraise_errors is true, this will delay throwing of the error until the next call to `synchronize_errors`.
+    # The logic of this method depends on when it is invoked.
+    #
+    # If it is invoked in the context of `synchronize_errors`, it will raise the error in the thread that is bound to `@reraise_target`.
+    # If it is invoked outside of `synchronize_errors`, it will record the error and kill the thread that called this method.
     #
     # @param args [Array] the arguments to raise, usually an exception class and a message
     def raise(*args)

--- a/test/beetle/bunny_behavior_test.rb
+++ b/test/beetle/bunny_behavior_test.rb
@@ -26,8 +26,6 @@ class BunnyBehaviorTest < Minitest::Test
     assert_equal({"bar" => "baz"}, headers["table"])
   end
 
-
-  
   test "publishing redundantly does not leave the garbage in dedup store" do
     Beetle.config.servers = "localhost:5672,localhost:5673"
     client = Beetle::Client.new
@@ -38,7 +36,7 @@ class BunnyBehaviorTest < Minitest::Test
     # empty the dedup store
     client.deduplication_store.flushdb
 
-    handler = TestHandler.new(stop_listening_after_n_post_processes = 2, client = client)
+    handler = TestHandler.new(2, client = client)
     client.register_handler(:test_garbage, handler)
     published = client.publish(:test_garbage, 'bam', :redundant =>true)
     listen(client)
@@ -49,9 +47,9 @@ class BunnyBehaviorTest < Minitest::Test
     message = messages_processed.first
     assert_equal 2, published
     assert_equal "bam", message.data
-    Beetle::DeduplicationStore::KEY_SUFFIXES.each{|suffix| 
-        assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
-    }
+    Beetle::DeduplicationStore::KEY_SUFFIXES.each do |suffix|
+      assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
+    end
   end
 
   test "process redundant message once" do
@@ -64,7 +62,7 @@ class BunnyBehaviorTest < Minitest::Test
     # empty the dedup store
     client.deduplication_store.flushdb
 
-    handler = TestHandler.new(stop_listening_after_n_post_processes = 2, client = client)
+    handler = TestHandler.new(2, client = client)
     client.register_handler(:test_processing, handler)
     published = client.publish(:test_processing, 'bam', :redundant =>true)
     listen(client)
@@ -98,9 +96,9 @@ class BunnyBehaviorTest < Minitest::Test
 
     assert_equal 1, published
     assert_equal "bam", message.data
-    Beetle::DeduplicationStore::KEY_SUFFIXES.map{|suffix| 
-        assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
-    }
+    Beetle::DeduplicationStore::KEY_SUFFIXES.map do |suffix|
+      assert_equal false, client.deduplication_store.exists(message.msg_id, suffix)
+    end
   end
 
   test "publishing with confirms works as expected" do
@@ -119,26 +117,46 @@ class BunnyBehaviorTest < Minitest::Test
     client.stop_publishing
 
     assert_equal 1, published
-    assert_equal "bam", message.data 
-
+    assert_equal "bam", message.data
   end
 
+  test "auto-recovery sleep is disabled" do
+    Beetle.config.servers = "localhost:5672"
+    client = Beetle::Client.new
+    client.register_message(:test_network)
 
-  def listen(client , timeout = 1) 
-    Timeout.timeout(timeout) do 
-      client.listen 
+    bunny = client.send(:publisher).send(:bunny)
+    transport = bunny.transport
+
+    def transport.closed?
+      true
     end
-  rescue Timeout::Error 
-       puts "Client listen timed out after #{timeout} seconds"
-       nil
+
+    def transport.open?
+      false
+    end
+
+    begin
+      Timeout.timeout(1) do
+        transport.send_frame(AMQ::Protocol::Channel::Open.encode(1, AMQ::Protocol::EMPTY_STRING))
+      end
+    rescue Timeout::Error
+      assert false, "Transport should not timeout when auto-recovery sleep is disabled"
+    end
   end
 
+  def listen(client, timeout = 1)
+    Timeout.timeout(timeout) do
+      client.listen
+    end
+  rescue Timeout::Error
+    puts "Client listen timed out after #{timeout} seconds"
+    nil
+  end
 
   class TestHandler < Beetle::Handler
 
-    attr_reader :messages_processed
-    attr_reader :pre_process_invocations
-    attr_reader :post_process_invocations
+    attr_reader :messages_processed, :pre_process_invocations, :post_process_invocations
 
     def initialize(stop_listening_after_n_post_processes, client)
       super()
@@ -149,22 +167,20 @@ class BunnyBehaviorTest < Minitest::Test
       @messages_processed = []
     end
 
-    def pre_process(message)
+    def pre_process(_message)
       @pre_process_invocations += 1
     end
-    
+
     def process
       @messages_processed << message
     end
 
     def post_process
       @post_process_invocations += 1
-      if @post_process_invocations >= @stop_listening_after_n_post_processes
-          @client.stop_listening
-      end
+      return unless @post_process_invocations >= @stop_listening_after_n_post_processes
+      @client.stop_listening
     end
 
   end
-
 
 end

--- a/test/beetle/publisher_integration_test.rb
+++ b/test/beetle/publisher_integration_test.rb
@@ -1,0 +1,52 @@
+require 'timeout'
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+require "toxiproxy"
+
+Toxiproxy.host = "http://127.0.0.1:8474"
+Toxiproxy.populate([
+                     { name: "rabbitmq1", listen: "0.0.0.0:5674", upstream: "rabbitmq1:5672" },
+                     { name: "rabbitmq2", listen: "0.0.0.0:5675", upstream: "rabbitmq2:5673" }
+                   ])
+
+class PublisherIntegrationTest < Minitest::Test
+  def setup
+    Toxiproxy[:rabbitmq1].enable
+    Toxiproxy[:rabbitmq2].enable
+  end
+
+  def rabbit1
+    Toxiproxy[:rabbitmq1]
+  end
+
+  def rabbit2
+    Toxiproxy[:rabbitmq2]
+  end
+
+  test "connect, server goes down, publish failure, server comes back up, publish succeeds" do
+    config = Beetle.config.clone
+    config.servers = "127.0.0.1:5674"
+    client = Beetle::Client.new(config)
+    client.register_message(:test_message)
+
+    assert_nothing_raised do
+      assert_equal 1, client.publish(:test_message, "test data")
+    end
+
+    rabbit1.down do
+      assert_nothing_raised do
+        sleep 1 # give bunny time to recognize the server is down
+      end
+
+      assert client.send(:publisher).exceptions?
+
+      assert_raises(Beetle::NoMessageSent) do
+        client.publish(:test_message, "test data")
+      end
+    end
+
+    # now we recover and we are fine again
+    assert_nothing_raised do
+      assert_equal 1, client.publish(:test_message, "test data")
+    end
+  end
+end

--- a/test/beetle/publisher_integration_test.rb
+++ b/test/beetle/publisher_integration_test.rb
@@ -112,7 +112,7 @@ class PublisherIntegrationTest < Minitest::Test
         end
 
         refute client.send(:publisher).send(:bunny?) # no bunny active
-        assert_match(/Connection reset by peer/, logs.string)
+        assert_match(/Beetle: publishing exception/, logs.string)
       end
     end
 

--- a/test/beetle/publisher_integration_test.rb
+++ b/test/beetle/publisher_integration_test.rb
@@ -127,6 +127,9 @@ class PublisherIntegrationTest < Minitest::Test
     end
   end
 
+  # TODO: verify that reset (between 2 heartbeats) is leading to a publishing error
+  # connect, publish success, tcp reset on next publish, no hearbeat send yet, publish should fail
+
   test "connect, timeout + empty response, publish succeeds again" do
     with_client("127.0.0.1:5674") do |client|
       # connect

--- a/test/beetle/publisher_integration_test.rb
+++ b/test/beetle/publisher_integration_test.rb
@@ -49,7 +49,7 @@ class PublisherIntegrationTest < Minitest::Test
 
         # connected(1 heartbeat sender)
         rabbit1.down do
-          sleep 0.5 # give bunny time to recognize the server is down
+          wait_until { client.send(:publisher).exceptions? }
         end
 
         # bunny is now exception state, 1 hearbeat sender
@@ -58,7 +58,7 @@ class PublisherIntegrationTest < Minitest::Test
         end
 
         rabbit1.down do
-          sleep 0.5 # give bunny time to recognize the server is down
+          wait_until { client.send(:publisher).exceptions? }
         end
 
         assert_nothing_raised do
@@ -79,7 +79,7 @@ class PublisherIntegrationTest < Minitest::Test
         # connected(1 heartbeat sender)
         rabbit1.down do
           rabbit2.down do
-            sleep 0.5 # give bunny time to recognize the server is down
+            wait_until { client.send(:publisher).exceptions? }
           end
         end
 
@@ -90,7 +90,7 @@ class PublisherIntegrationTest < Minitest::Test
 
         rabbit1.down do
           rabbit2.down do
-            sleep 0.5 # give bunny time to recognize the server is down
+            wait_until { client.send(:publisher).exceptions? }
           end
         end
 
@@ -190,7 +190,7 @@ class PublisherIntegrationTest < Minitest::Test
 
         rabbit1.down do
           assert_nothing_raised do
-            sleep 1 # give bunny time to recognize the server is down
+            wait_until { client.send(:publisher).exceptions? }
           end
 
           assert client.send(:publisher).exceptions?
@@ -225,7 +225,7 @@ class PublisherIntegrationTest < Minitest::Test
         end
 
         rabbit1.down do
-          sleep 1 # give bunny time to recognize the server is down
+          wait_until { client.send(:publisher).exceptions? }
         end
 
         assert client.send(:publisher).exceptions?, "Publisher should have detected the server down"
@@ -262,7 +262,7 @@ class PublisherIntegrationTest < Minitest::Test
         refute client.send(:publisher).exceptions?
         # now publish with failure
         rabbit1.downstream(:timeout, timeout: 1).apply do
-          sleep 0.5
+          sleep 0.3
           assert_raises(Beetle::NoMessageSent) do
             client.publish(msg, "test data")
           end

--- a/test/beetle/publisher_integration_test.rb
+++ b/test/beetle/publisher_integration_test.rb
@@ -80,9 +80,21 @@ class PublisherIntegrationTest < Minitest::Test
   end
 
   # TODO: add tests for multiple servers
-  # TODO: add more tests for scenarios:
-  # * server down immediatly, fails, server comes up, succeeds
-  # *
+
+  test "server down, publish fails, server comes up, publish succeeds" do
+    client = create_client("127.0.0.1:5674")
+
+    rabbit1.down do
+      assert_raises(Beetle::NoMessageSent) do
+        client.publish(:test_message, "test data")
+      end
+    end
+
+    # server should be up again and we recover
+    assert_nothing_raised do
+      client.publish(:test_message, "test data")
+    end
+  end
 
   test "connect, timeout + empty response, publish succeeds again" do
     client = create_client("127.0.0.1:5674")

--- a/test/beetle/publisher_integration_test.rb
+++ b/test/beetle/publisher_integration_test.rb
@@ -55,6 +55,9 @@ class PublisherIntegrationTest < Minitest::Test
   end
 
   # TODO: add tests for multiple servers
+  # TODO: add more tests for scenarios:
+  # * server down immediatly, fails, server comes up, succeeds
+  # *
 
   test "connect, timeout + empty response, publish succeeds again" do
     config = Beetle.config.clone

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -137,6 +137,20 @@ module Beetle
       end
     end
 
+    def test_nested_call_error_does_not_change_state_of_synchronization
+      @handler.synchronize_errors do
+        # now the internal state is that we synchronize
+        assert @handler.synchronous_errors?, "Expected to be in synchronized state after first call"
+        assert_raises(Beetle::PublisherSessionErrorHandler::SynchronizationError) do
+          @handler.synchronize_errors do
+            sleep 0.1
+          end
+        end
+        # previous block raised but we still expect to be in the synchronized state
+        assert @handler.synchronous_errors?, "Expected to still be in synchronized state after nested call error"
+      end
+    end
+
     def test_synchronize_errors_on_different_thread_prohibited
       Thread.report_on_exception = false # prevent the thread from reporting exceptions just for this test
       other_thread = Thread.new do

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -1,0 +1,122 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+module Beetle
+  class PublisherSessionErrorHandlerTest < Minitest::Test
+    class DummyPublisher; end
+    BackgroundError = Class.new(StandardError)
+    ForgroundError = Class.new(StandardError)
+    DelayedError = Class.new(StandardError)
+
+    def setup
+      @logger_output = StringIO.new
+      @logger = Logger.new(@logger_output)
+      @publisher = DummyPublisher.new
+      @handler = Beetle::PublisherSessionErrorHandler.new(@logger, @publisher, "test-server")
+    end
+
+    def test_synchronize_errors_with_recorded_errors_from_background_thread
+      background = Thread.new do
+        @handler.raise(BackgroundError.new("Background error"))
+      end
+
+      sleep 0.5 # ensure that error is recorded while reraising is still false
+
+      assert_raises(BackgroundError) do
+        @handler.synchronize_errors do
+          assert false, "synchronize_errors was expected to raise previously recorded error"
+        end
+      end
+
+      background.join
+    end
+
+    def test_synchronize_errors_with_errors_from_background_thread_during_reraising
+      background = Thread.new do
+        sleep 0.5 # give the main thread time to call synchronize_errors
+        @handler.raise(BackgroundError.new("Background error"))
+      end
+
+      assert_raises(BackgroundError) do
+        @handler.synchronize_errors do
+          sleep 0.7 # wait for the background thread to raise
+
+          assert false, "synchronize_errors was expected to raise"
+        end
+      end
+
+      background.join
+    end
+
+    def test_synchronize_errors_with_errors_from_main_thread
+      assert_raises(ForgroundError) do
+        @handler.synchronize_errors do
+          raise ForgroundError.new("Foreground error")
+        end
+      end
+    end
+
+    def test_synchronize_errors_with_no_errors_succeeds
+      assert_nothing_raised do
+        result = @handler.synchronize_errors do
+          "No errors here"
+        end
+
+        assert_equal "No errors here", result
+      end
+    end
+
+    def test_records_exception_if_not_reraising
+      @handler.raise(DelayedError.new("Delayed error"))
+      assert @handler.exceptions?
+
+      assert_raises(DelayedError) do
+        @handler.synchronize_errors { } # should raise immediately
+      end
+    end
+
+    def test_does_not_reraise_without_reraising_context
+      assert_nothing_raised do
+        @handler.raise(DelayedError.new("Should not raise"))
+        assert @handler.exceptions?
+      end
+    end
+
+    def test_reraising_errors_resets_state
+      @handler.raise(BackgroundError.new("First"))
+
+      assert_raises(BackgroundError) do
+        @handler.synchronize_errors {}
+      end
+
+      # after that we should not have any recorded exceptions
+      refute @handler.exceptions?
+
+      assert_nothing_raised do
+        @handler.synchronize_errors {}
+      end
+    end
+
+    def test_kills_background_thread
+      bg = Thread.new do
+        @handler.raise(BackgroundError.new("die!"))
+        sleep 0.7
+      end
+
+      sleep 0.3
+      refute bg.alive?
+
+      bg.join(0.2)
+    end
+
+    def test_logs_errors
+      error_message = "Test error"
+      @handler.raise(DelayedError.new(error_message))
+
+      assert_raises(DelayedError) do
+        @handler.synchronize_errors {}
+      end
+
+      assert_match(/Beetle: bunny session handler errror. server=test-server reraise=false/, @logger_output.string)
+    end
+  end
+end

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -4,7 +4,7 @@ module Beetle
   class PublisherSessionErrorHandlerTest < Minitest::Test
     class DummyPublisher; end
     BackgroundError = Class.new(StandardError)
-    ForgroundError = Class.new(StandardError)
+    ForegroundError = Class.new(StandardError)
     DelayedError = Class.new(StandardError)
 
     def setup

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -21,7 +21,7 @@ module Beetle
       assert @handler.exception?, "Handler should have recorded an exception"
 
       assert_raises(BackgroundError) do
-        @handler.raise_pending_error!
+        @handler.raise_pending_exception!
       end
 
       refute background.alive?, "Background thread should be terminated after raising an error"
@@ -65,23 +65,23 @@ module Beetle
       assert_match(/Beetle: bunny session handler error. server=test-server/, @logger_output.string)
     end
 
-    test "#raise_pending_error! raises the recorded error" do
+    test "#raise_pending_exception! raises the recorded error" do
       @handler.raise(ForegroundError.new("Foreground error"))
       assert_raises(ForegroundError) do
-        @handler.raise_pending_error!
+        @handler.raise_pending_exception!
       end
     end
 
-    test "#raise_pending_error! does not raise if no error was recorded" do
+    test "#raise_pending_exception! does not raise if no error was recorded" do
       assert_nothing_raised do
-        @handler.raise_pending_error!
+        @handler.raise_pending_exception!
       end
     end
 
-    test "#raise_pending_error! clears the recorded error" do
+    test "#raise_pending_exception! clears the recorded error" do
       @handler.raise(ForegroundError.new("Foreground error"))
       assert_raises(ForegroundError) do
-        @handler.raise_pending_error!
+        @handler.raise_pending_exception!
       end
 
       refute @handler.exception?, "Handler should not have any recorded exceptions after raising"

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -48,9 +48,9 @@ module Beetle
     end
 
     def test_synchronize_errors_with_errors_from_main_thread
-      assert_raises(ForgroundError) do
+      assert_raises(ForegroundError) do
         @handler.synchronize_errors do
-          raise ForgroundError.new("Foreground error")
+          raise ForegroundError.new("Foreground error")
         end
       end
     end

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -17,8 +17,7 @@ module Beetle
         @handler.raise(BackgroundError.new("Background error"))
       end
 
-      sleep 0.2
-      assert @handler.exception?, "Handler should have recorded an exception"
+      wait_until { @handler.exception? }
 
       assert_raises(BackgroundError) do
         @handler.raise_pending_exception!
@@ -34,11 +33,10 @@ module Beetle
         sleep 1
       end
 
-      sleep 0.2
       assert th.alive?, "Thread should be alive even after raising an error"
 
       assert_nothing_raised do
-        th.join(1) # wait for the thread to finish
+        th.join(0.5) # wait for the thread to finish
       end
     end
 
@@ -50,12 +48,11 @@ module Beetle
         sleep 1
       end
 
-      sleep 0.2
-      assert handler.exception?, "Handler should have recorded an exception"
+      wait_until { handler.exception? }
       assert th.alive?, "Thread should be alive even after raising an error"
 
       assert_nothing_raised do
-        th.join(1) # wait for the thread to finish
+        th.join(0.5) # wait for the thread to finish
       end
     end
 

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -12,7 +12,7 @@ module Beetle
       @handler = Beetle::PublisherSessionErrorHandler.new(@logger, "test-server")
     end
 
-    test "#raise records the error and terminates the thread" do
+    test "#raise records the error" do
       background = Thread.new do
         @handler.raise(BackgroundError.new("Background error"))
       end
@@ -23,37 +23,7 @@ module Beetle
         @handler.raise_pending_exception!
       end
 
-      refute background.alive?, "Background thread should be terminated after raising an error"
-    end
-
-    test "#raise does not terminate the thread in which error handler has been created" do
-      th = Thread.new do
-        handler = Beetle::PublisherSessionErrorHandler.new(@logger, "test-server")
-        handler.raise(DelayedError.new("Should not kill main thread"))
-        sleep 1
-      end
-
-      assert th.alive?, "Thread should be alive even after raising an error"
-
-      assert_nothing_raised do
-        th.join(0.5) # wait for the thread to finish
-      end
-    end
-
-    test "#raise does not terminate the thread if terminate_thread_on_raise is false" do
-      handler = Beetle::PublisherSessionErrorHandler.new(@logger, "test-server", terminate_thread_on_raise: false)
-
-      th = Thread.new do
-        handler.raise(DelayedError.new("Should not kill main thread"))
-        sleep 1
-      end
-
-      wait_until { handler.exception? }
-      assert th.alive?, "Thread should be alive even after raising an error"
-
-      assert_nothing_raised do
-        th.join(0.5) # wait for the thread to finish
-      end
+      background.join
     end
 
     test "#raise logs the error" do

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -108,6 +108,21 @@ module Beetle
       bg.join(0.2)
     end
 
+    def test_never_kills_the_thread_in_which_handler_is_created
+      th = Thread.new do
+        handler = Beetle::PublisherSessionErrorHandler.new(@logger, @publisher, "test-server")
+        sleep 0.1
+        handler.raise(DelayedError.new("Should not kill main thread"))
+        sleep 1
+      end
+
+      assert th.alive?, "Thread should be alive even after raising an error"
+
+      assert_nothing_raised do
+        th.join(1) # wait for the thread to finish
+      end
+    end
+
     def test_logs_errors
       error_message = "Test error"
       @handler.raise(DelayedError.new(error_message))

--- a/test/beetle/publisher_session_error_handler_test.rb
+++ b/test/beetle/publisher_session_error_handler_test.rb
@@ -2,7 +2,6 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 module Beetle
   class PublisherSessionErrorHandlerTest < Minitest::Test
-    class DummyPublisher; end
     BackgroundError = Class.new(StandardError)
     ForegroundError = Class.new(StandardError)
     DelayedError = Class.new(StandardError)
@@ -13,113 +12,29 @@ module Beetle
       @handler = Beetle::PublisherSessionErrorHandler.new(@logger, "test-server")
     end
 
-    def test_synchronize_errors_with_recorded_errors_from_background_thread
+    test "#raise records the error and terminates the thread" do
       background = Thread.new do
         @handler.raise(BackgroundError.new("Background error"))
       end
 
-      sleep 0.5 # ensure that error is recorded while reraising is still false
+      sleep 0.2
+      assert @handler.exception?, "Handler should have recorded an exception"
 
       assert_raises(BackgroundError) do
-        @handler.synchronize_errors do
-          assert false, "synchronize_errors was expected to raise previously recorded error"
-        end
+        @handler.raise_pending_error!
       end
 
-      background.join
+      refute background.alive?, "Background thread should be terminated after raising an error"
     end
 
-    def test_synchronize_errors_with_errors_from_background_thread_during_reraising
-      raise_now = false
-
-      background = Thread.new do
-        loop do
-          sleep 0.1 # give the main thread time to call synchronize_errors
-          break if raise_now
-        end
-        @handler.raise(BackgroundError.new("Background error"))
-      end
-
-      assert_raises(BackgroundError) do
-        @handler.synchronize_errors do
-          raise_now = true
-          sleep 0.5
-          assert false, "synchronize_errors was expected to raise"
-        end
-      end
-
-      background.join
-    end
-
-    def test_synchronize_errors_with_errors_from_main_thread
-      assert_raises(ForegroundError) do
-        @handler.synchronize_errors do
-          raise ForegroundError.new("Foreground error")
-        end
-      end
-    end
-
-    def test_synchronize_errors_with_no_errors_succeeds
-      assert_nothing_raised do
-        result = @handler.synchronize_errors do
-          "No errors here"
-        end
-
-        assert_equal "No errors here", result
-      end
-    end
-
-    def test_records_exception_if_not_reraising
-      @handler.raise(DelayedError.new("Delayed error"))
-      assert @handler.exceptions?
-
-      assert_raises(DelayedError) do
-        @handler.synchronize_errors { } # should raise immediately
-      end
-    end
-
-    def test_does_not_reraise_without_reraising_context
-      assert_nothing_raised do
-        @handler.raise(DelayedError.new("Should not raise"))
-        assert @handler.exceptions?
-      end
-    end
-
-    def test_reraising_errors_resets_state
-      @handler.raise(BackgroundError.new("First"))
-
-      assert_raises(BackgroundError) do
-        @handler.synchronize_errors {}
-      end
-
-      # after that we should not have any recorded exceptions
-      refute @handler.exceptions?
-
-      assert_nothing_raised do
-        @handler.synchronize_errors {}
-      end
-    end
-
-    def test_kills_background_thread
-      bg = Thread.new do
-        @handler.raise(BackgroundError.new("die!"))
-        sleep 0.7
-      end
-
-      sleep 0.3
-      refute bg.alive?
-
-      bg.join(0.2)
-    end
-
-    def test_never_kills_the_thread_in_which_handler_is_created
+    test "#raise does not terminate the thread in which error handler has been created" do
       th = Thread.new do
         handler = Beetle::PublisherSessionErrorHandler.new(@logger, "test-server")
-        sleep 0.1
         handler.raise(DelayedError.new("Should not kill main thread"))
         sleep 1
       end
 
+      sleep 0.2
       assert th.alive?, "Thread should be alive even after raising an error"
 
       assert_nothing_raised do
@@ -127,52 +42,55 @@ module Beetle
       end
     end
 
-    def test_nesting_calls_to_synchronize_errors_prohibited
-      assert_raises(Beetle::PublisherSessionErrorHandler::SynchronizationError) do
-        @handler.synchronize_errors do
-          @handler.synchronize_errors do
-            sleep 0.1
-          end
-        end
+    test "#raise does not terminate the thread if terminate_thread_on_raise is false" do
+      handler = Beetle::PublisherSessionErrorHandler.new(@logger, "test-server", terminate_thread_on_raise: false)
+
+      th = Thread.new do
+        handler.raise(DelayedError.new("Should not kill main thread"))
+        sleep 1
+      end
+
+      sleep 0.2
+      assert handler.exception?, "Handler should have recorded an exception"
+      assert th.alive?, "Thread should be alive even after raising an error"
+
+      assert_nothing_raised do
+        th.join(1) # wait for the thread to finish
       end
     end
 
-    def test_nested_call_error_does_not_change_state_of_synchronization
-      @handler.synchronize_errors do
-        # now the internal state is that we synchronize
-        assert @handler.synchronous_errors?, "Expected to be in synchronized state after first call"
-        assert_raises(Beetle::PublisherSessionErrorHandler::SynchronizationError) do
-          @handler.synchronize_errors do
-            sleep 0.1
-          end
-        end
-        # previous block raised but we still expect to be in the synchronized state
-        assert @handler.synchronous_errors?, "Expected to still be in synchronized state after nested call error"
-      end
-    end
-
-    def test_synchronize_errors_on_different_thread_prohibited
-      Thread.report_on_exception = false # prevent the thread from reporting exceptions just for this test
-      other_thread = Thread.new do
-        @handler.synchronize_errors {}
-      end
-
-      assert_raises(Beetle::PublisherSessionErrorHandler::SynchronizationError) do
-        other_thread.join # join will re-raise any exception before
-      end
-    ensure
-      Thread.report_on_exception = true # restore the default behavior
-    end
-
-    def test_logs_errors
+    test "#raise logs the error" do
       error_message = "Test error"
       @handler.raise(DelayedError.new(error_message))
+      assert_match(/Beetle: bunny session handler error. server=test-server/, @logger_output.string)
+    end
 
-      assert_raises(DelayedError) do
-        @handler.synchronize_errors {}
+    test "#raise_pending_error! raises the recorded error" do
+      @handler.raise(ForegroundError.new("Foreground error"))
+      assert_raises(ForegroundError) do
+        @handler.raise_pending_error!
+      end
+    end
+
+    test "#raise_pending_error! does not raise if no error was recorded" do
+      assert_nothing_raised do
+        @handler.raise_pending_error!
+      end
+    end
+
+    test "#raise_pending_error! clears the recorded error" do
+      @handler.raise(ForegroundError.new("Foreground error"))
+      assert_raises(ForegroundError) do
+        @handler.raise_pending_error!
       end
 
-      assert_match(/Beetle: bunny session handler error. server=test-server reraise=false/, @logger_output.string)
+      refute @handler.exception?, "Handler should not have any recorded exceptions after raising"
+    end
+
+    test "#clear_exception! returns the arguments for the raise and clears it" do
+      @handler.raise(ForegroundError, "Foreground error")
+      args = @handler.clear_exception!
+      assert_equal [ForegroundError, "Foreground error"], args
     end
   end
 end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -69,6 +69,29 @@ module Beetle
       assert_equal bunny_mock, pub.send(:new_bunny)
     end
 
+    test "new bunnies should be created with auto-recovery disabled" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+      config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
+      client = Client.new(config)
+      pub = Publisher.new(client)
+
+      bunny_mock = mock("dummy_bunny")
+      expected_bunny_options = {
+        automatically_recover: false,
+        recover_from_connection_close: false,
+        network_recovery_interval: 0
+      }
+
+      Bunny
+        .expects(:new)
+        .with { |actual| expected_bunny_options.all? { |k, v| actual[k] == v }  } # match our subset of options
+        .returns(bunny_mock)
+      bunny_mock.expects(:start)
+      assert_equal bunny_mock, pub.send(:new_bunny)
+    end
+
+
     test "initially there should be no bunnies" do
       assert_equal({}, @pub.instance_variable_get("@bunnies"))
     end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -100,45 +100,94 @@ module Beetle
       assert_equal({}, @pub.instance_variable_get("@dead_servers"))
     end
 
-    test "stop! should shut down bunny and clean internal data structures" do
+    test "stop_bunny_forcefully! closes the bunny socket and all threads" do
       b = mock("bunny")
-      @pub.expects(:bunny?).returns(true)
-      @pub.expects(:bunny).returns(b)
-      @pub.send(:stop!)
-      assert_equal({}, @pub.send(:exchanges))
-      assert_equal({}, @pub.send(:queues))
-      assert_nil @pub.instance_variable_get(:@bunnies)[@pub.server]
-      assert_nil @pub.instance_variable_get(:@channels)[@pub.server]
-    end
+      reader_loop = mock("reader_loop")
 
-    test "stop!(exception) should close the bunny socket if an exception is not nil" do
-      b = mock("bunny")
-      l = mock("loop")
-      b.expects(:close_connection)
       b.expects(:maybe_shutdown_heartbeat_sender).returns(true)
-      b.expects(:reader_loop).returns(l)
-      l.expects(:kill)
-      @pub.expects(:bunny?).returns(true)
-      @pub.expects(:bunny).returns(b).times(3)
-      @pub.send(:stop!, Exception.new)
-      assert_equal({}, @pub.send(:exchanges))
-      assert_equal({}, @pub.send(:queues))
-      assert_nil @pub.instance_variable_get(:@bunnies)[@pub.server]
-      assert_nil @pub.instance_variable_get(:@bunny_error_handlers)[@pub.server]
-      assert_nil @pub.instance_variable_get(:@channels)[@pub.server]
+      b.expects(:reader_loop).returns(reader_loop)
+      reader_loop.expects(:kill)
+      b.expects(:close_connection, false)
+
+      @pub.expects(:bunny).returns(b).at_least_once
+
+      @pub.send(:stop_bunny_forcefully!, Exception.new)
     end
 
-    test "stop!(exception) with error on shutdown of hearbeat sender continues to close the rest" do
+    test "stop_bunny_forcefully! fails on shutdown of heartbeat sender, but continues to cleanup " do
       b = mock("bunny")
-      l = mock("loop")
-      b.expects(:close_connection)
-      b.expects(:maybe_shutdown_heartbeat_sender).raises(RuntimeError, "error on shutdown of heartbeat sender")
+      reader_loop = mock("reader_loop")
 
-      b.expects(:reader_loop).returns(l)
-      l.expects(:kill)
+      b.expects(:maybe_shutdown_heartbeat_sender).raises(RuntimeError, "error on shutdown of heartbeat sender")
+      b.expects(:reader_loop).returns(reader_loop)
+      reader_loop.expects(:kill)
+      b.expects(:close_connection, false)
+
+      @pub.expects(:bunny).returns(b).at_least_once
+
+      assert_raises(Beetle::PublisherShutdownError) do
+        @pub.send(:stop_bunny_forcefully!, Exception.new)
+      end
+    end
+
+    test "stop_bunny_forcefully! fails on shutdown of reader_loop, but continues to cleanup " do
+      b = mock("bunny")
+      reader_loop = mock("reader_loop")
+
+      b.expects(:maybe_shutdown_heartbeat_sender).returns(true)
+      b.expects(:reader_loop).returns(reader_loop)
+      reader_loop.expects(:kill).raises(RuntimeError, "error on shutdown of reader_loop")
+      b.expects(:close_connection, false)
+
+      @pub.expects(:bunny).returns(b).at_least_once
+
+      assert_raises(Beetle::PublisherShutdownError) do
+        @pub.send(:stop_bunny_forcefully!, Exception.new)
+      end
+    end
+
+    test "stop_bunny_forcefully! fails on close connection" do
+      b = mock("bunny")
+      reader_loop = mock("reader_loop")
+
+      b.expects(:maybe_shutdown_heartbeat_sender).returns(true)
+      b.expects(:reader_loop).returns(reader_loop)
+      reader_loop.expects(:kill)
+      b.expects(:close_connection, false).raises(Timeout::Error, "error on close connection")
+
+      @pub.expects(:bunny).returns(b).at_least_once
+
+      assert_raises(Beetle::PublisherShutdownError) do
+        @pub.send(:stop_bunny_forcefully!, Exception.new)
+      end
+    end
+
+    test "stop_bunny_forcefully! raises partial shutdown error with collected errors" do
+      b = mock("bunny")
+      reader_loop = mock("reader_loop")
+
+      b.expects(:maybe_shutdown_heartbeat_sender).raises(RuntimeError, "error on shutdown of heartbeat sender")
+      b.expects(:reader_loop).returns(reader_loop)
+      reader_loop.expects(:kill)
+      b.expects(:close_connection, false).raises(Timeout::Error, "error on close connection")
+
+      @pub.expects(:bunny).returns(b).at_least_once
+
+      begin
+        @pub.send(:stop_bunny_forcefully!, Exception.new)
+        assert false, "Expected PublisherShutdownError to be raised"
+      rescue Beetle::PublisherShutdownError => e
+        assert_equal 2, e.errors.size
+        assert_equal RuntimeError, e.errors.first.class
+        assert_equal Timeout::Error, e.errors.last.class
+        assert_match(/Publisher failed to shutdown bunny for server localhost:5672/, e.message)
+      end
+    end
+
+    test "stop! should shut down bunny and clean internal data structures" do
       @pub.expects(:bunny?).returns(true)
-      @pub.expects(:bunny).returns(b).times(3)
-      @pub.send(:stop!, Exception.new)
+      @pub.expects(:stop_bunny_forcefully!).with(nil).returns(true)
+      @pub.send(:stop!)
       assert_equal({}, @pub.send(:exchanges))
       assert_equal({}, @pub.send(:queues))
       assert_nil @pub.instance_variable_get(:@bunnies)[@pub.server]
@@ -155,7 +204,6 @@ module Beetle
       assert_nil @pub.instance_variable_get(:@bunnies)[@pub.server]
       assert_nil @pub.instance_variable_get(:@channels)[@pub.server]
     end
-
   end
 
   class PublisherPublishingTest < Minitest::Test

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -180,7 +180,7 @@ module Beetle
         assert_equal 2, e.errors.size
         assert_equal RuntimeError, e.errors.first.class
         assert_equal Timeout::Error, e.errors.last.class
-        assert_match(/Publisher failed to shutdown bunny for server localhost:5672/, e.message)
+        assert_match(/Publisher failed to shutdown bunny for server localhost/, e.message)
       end
     end
 

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -91,7 +91,6 @@ module Beetle
       assert_equal bunny_mock, pub.send(:new_bunny)
     end
 
-
     test "initially there should be no bunnies" do
       assert_equal({}, @pub.instance_variable_get("@bunnies"))
     end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -298,7 +298,7 @@ module Beetle
       @pub.expects(:exchange).with("mama-exchange").returns(e).in_sequence(redundant)
       e.expects(:publish).raises(Bunny::ConnectionError, '').in_sequence(redundant)
 
-      assert_raises Beetle::NoMessageSent do
+      assert_raises(Beetle::NoMessageSent) do
         @pub.publish_with_redundancy("mama-exchange", "mama", @data, @opts)
       end
     end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -116,14 +116,16 @@ module Beetle
       b = mock("bunny")
       l = mock("loop")
       b.expects(:close_connection)
+      b.expects(:maybe_shutdown_heartbeat_sender).returns(true)
       b.expects(:reader_loop).returns(l)
       l.expects(:kill)
       @pub.expects(:bunny?).returns(true)
-      @pub.expects(:bunny).returns(b).twice
+      @pub.expects(:bunny).returns(b).times(3)
       @pub.send(:stop!, Exception.new)
       assert_equal({}, @pub.send(:exchanges))
       assert_equal({}, @pub.send(:queues))
       assert_nil @pub.instance_variable_get(:@bunnies)[@pub.server]
+      assert_nil @pub.instance_variable_get(:@bunny_error_handlers)[@pub.server]
       assert_nil @pub.instance_variable_get(:@channels)[@pub.server]
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,6 +63,15 @@ def unique_name(prefix)
   "#{prefix}_#{SecureRandom.uuid}"
 end
 
+def wait_until(timeout = 1.0)
+  Timeout.timeout(timeout) do
+    loop do
+      return if yield
+      Thread.pass
+    end
+  end
+end
+
 if system('docker -v >/dev/null') && `docker inspect beetle-mysql -f '{{.State.Status}}'`.chomp == "running"
   ENV['MYSQL_PORT'] = '6612'
 end


### PR DESCRIPTION
By default bunny, unfortunately, uses `Thread.current` as the [session_error_handler](https://github.com/ruby-amqp/bunny/blob/fba2bc8b039d04ce8a5d1e63879569cb8e96da13/lib/bunny/session.rb#L135).
This means that bunny threads, like the reader_loop or the heartbeat_sender will raise an async exception on the thread,
that created the bunny session. Usually that's the main thread of the application.

This also means that main thread execution can be interrupted essentially everywhere from the background threads, 
which is surprising and can leave the application in a very bad state.

This introduces a session error handler that mitigates this.
Bunny allows to configure the session error handler, and with this PR we provide our own implementation. 


## Design decisions and considered failure modes

The overall idea of the custom error handler, is to collect errors in the background, and only signal them at places where the calling code is prepared to handle them. This is done by providing a custom session_error handler, that implements `#raise`.

The main API for the error handler is:

`PublisherSessionErrorHandler#raise(*args)` which collects the error.
`PublisherSessionErrorHandler#raise_pending_error` which raises any previously recorded error in the current thread.

This allows our publisher to control, when it is ready to handle errors, the rest of the application remains undisturbed, and we can use our existing cleanup logic to make sure we recover safely from any connection errors.

### Why not collect all exceptions?
This could easily lead to a memory leak, when a lot of exceptions are handled but `#raise_pending_error` isn't called.
This is bad for any longer running application, that can be subjected to prolonged network issues.

### Why collect the first exception instead of the last?
I had no clear preference but it seemed more faithful and expected to fail with the first error seen, rather than the last.
I do not think it matters much.

### What if the recorded exception holds a reference to some resource?

That could again be a real problem in cases where `#raise_pending_exception` is called sparringly, because
the resource will not be gc'd until the error is cleared.

We could prevent that by just storing the information about the exception like the class name and the message, but not the original exception itself. 

The downside is that when we finally throw that exception, we wouldn't have all the information in the exception handling code anymore. That's why I currently opted to just store the error as is.

### Why does the error handler kill the thread that calls raise?

Usually you expect no code to be executed after a call to raise. 
In addition we know that the thread is in a bad state. So rather than keeping it in a bad state, potentially with 
a reconnect loop, we kill it so it's stopping it's work.
The threads we are concerned about are the reader_loop and heartbeat_sender.
We make sure not to kill the thread that holds the reference to the bunny session and the session error handler.

There is a potential downside to this. If we kill the reader loop, all code that requires a response from the server
will run into the continuation timeout (unless the connection is reset proactively). This should be fine.

### Why is the publisher handling exceptions on a per server basis?

This is not only what you would expect, but it's also required to make sure the cleanup and recovery code is triggered only for the currently selected server. If we surfaced all errors from all bunnies during synchronization, an error in the reader_loop of server2 could cause an exception which would lead to a recovery of server1, if that's the server that's currently selected. Of course this is not what we want to do.

