### PR TITLE
(publisher): separate timeouts

### DIFF
--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -104,8 +104,12 @@ module Beetle
     # to 2047, which is the RabbitMQ default in 3.7.  We can't set this to 0 because of a bug
     # in bunny.
     attr_accessor :channel_max
-    # the heartbeat interval to set for connections in seconds (defaults to <tt>0</tt>)
+
+    # the publisher heartbeat interval to set for connections in seconds (defaults to <tt>:server</tt> which means use what the server suggests)
     attr_accessor :heartbeat
+    alias publisher_heartbeat heartbeat
+    alias publisher_heartbeat= heartbeat=
+
     # Lazy queues have the advantage of consuming a lot less memory on the broker. For backwards
     # compatibility, they are disabled by default.
     attr_accessor :lazy_queues_enabled
@@ -139,9 +143,14 @@ module Beetle
     # Returns the port on which the Rabbit API is hosted
     attr_accessor :api_port
 
-    # The socket timeout in seconds for message publishing (defaults to <tt>0</tt>).
-    # consider this a highly experimental feature for now.
-    attr_accessor :publishing_timeout
+    # The TCP read timeout in seconds for the publishing connection (defaults to <tt>5</tt>)
+    attr_accessor :publisher_read_timeout
+
+    # The TCP write timeout in seconds for the publishing connection (defaults to <tt>5</tt>)
+    attr_accessor :publisher_write_timeout
+
+    # The timeout for operations that expect a response from the server (defaults to <tt>5</tt>)
+    attr_accessor :publisher_read_response_timeout
 
     # the connect/disconnect timeout in seconds for the publishing connection
     # (defaults to <tt>5</tt>).
@@ -222,7 +231,7 @@ module Beetle
       self.frame_max = 131072
       self.channel_max = 2047
       self.prefetch_count = 1
-      self.heartbeat = :server # use the server's heartbeat setting
+      self.heartbeat = :server # use the server's heartbeat setting for publishers
 
       self.dead_lettering_enabled = false
       self.dead_lettering_msg_ttl = 1000   # 1 second
@@ -234,9 +243,6 @@ module Beetle
 
       self.update_queue_properties_synchronously = false
 
-      self.publishing_timeout = 5 # seconds
-      self.publisher_connect_timeout = 5 # seconds
-
       self.subscriber_connect_timeout = 5 # seconds
       self.subscriber_reconnect_delay = 10 # seconds
       self.subscriber_heartbeat = 0
@@ -244,6 +250,11 @@ module Beetle
       self.tmpdir = "/tmp"
 
       self.log_file = STDOUT
+
+      self.publisher_connect_timeout = 5
+      self.publisher_read_timeout = 5
+      self.publisher_write_timeout = 5
+      self.publisher_read_response_timeout = 5
 
       self.publisher_confirms = false
       self.publisher_lazy_queue_setup = true

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -149,7 +149,7 @@ module Beetle
     # The TCP write timeout in seconds for the publishing connection (defaults to <tt>5</tt>)
     attr_accessor :publisher_write_timeout
 
-    # The timeout for operations that expect a response from the server (defaults to <tt>5</tt>)
+    # The timeout in seconds for operations that expect a response from the server (defaults to <tt>5</tt>)
     attr_accessor :publisher_read_response_timeout
 
     # the connect/disconnect timeout in seconds for the publishing connection

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -248,9 +248,9 @@ module Beetle
         :logger                => @client.config.logger,
         :frame_max             => @client.config.frame_max,
         :channel_max           => @client.config.channel_max,
-        :read_timeout          => @client.config.publishing_timeout,
-        :write_timeout         => @client.config.publishing_timeout,
-        :continuation_timeout  => @client.config.publishing_timeout * 1000, # continuation timeout is in milliseconds while the other timeouts are in seconds :/
+        :read_timeout          => @client.config.publisher_read_timeout,
+        :write_timeout         => @client.config.publisher_write_timeout,
+        :continuation_timeout  => @client.config.publisher_read_response_timeout * 1000, # continuation timeout is in milliseconds while the other timeouts are in seconds :/
         :connection_timeout    => @client.config.publisher_connect_timeout,
         :heartbeat             => @client.config.heartbeat,
 

--- a/test/beetle/configuration_test.rb
+++ b/test/beetle/configuration_test.rb
@@ -1,6 +1,75 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 module Beetle
+  class ConfigurationDefaultValues < Minitest::Test
+    def setup
+      @config = Configuration.new
+    end
+
+    test "publisher_heartbeat => :server" do
+      assert_equal :server, @config.publisher_heartbeat
+    end
+
+    test "publisher_heartbeat can be changed" do
+      @config.publisher_heartbeat = 10
+      assert_equal 10, @config.publisher_heartbeat
+    end
+
+    test "publisher_connect_timeout => 5" do
+      assert_equal 5, @config.publisher_connect_timeout
+    end
+
+    test "publisher_connect_timeout can be changed" do
+      @config.publisher_connect_timeout = 10
+      assert_equal 10, @config.publisher_connect_timeout
+    end
+
+    test "publisher_read_timeout => 5" do
+      assert_equal 5, @config.publisher_read_timeout
+    end
+
+    test "publisher_read_timeout can be changed" do
+      @config.publisher_read_timeout = 10
+      assert_equal 10, @config.publisher_read_timeout
+    end
+
+    test "publisher_write_timeout => 5" do
+      assert_equal 5, @config.publisher_write_timeout
+    end
+
+    test "publisher_write_timeout can be changed" do
+      @config.publisher_write_timeout = 10
+      assert_equal 10, @config.publisher_write_timeout
+    end
+
+    test "publisher_read_response_timeout => 5" do
+      assert_equal 5, @config.publisher_read_response_timeout
+    end
+
+    test "publisher_read_response_timeout can be changed" do
+      @config.publisher_read_response_timeout = 10
+      assert_equal 10, @config.publisher_read_response_timeout
+    end
+
+    test "publisher_confirms => false" do
+      refute @config.publisher_confirms
+    end
+
+    test "publisher_confirms can be changed" do
+      @config.publisher_confirms = true
+      assert @config.publisher_confirms
+    end
+
+    test "publisher_lazy_queue_setup => true" do
+      assert @config.publisher_lazy_queue_setup
+    end
+
+    test "publisher_lazy_queue_setup can be changed" do
+      @config.publisher_lazy_queue_setup = false
+      refute @config.publisher_lazy_queue_setup
+    end
+  end
+
   class ConfigurationTest < Minitest::Test
     test "should load it's settings from a config file if that file exists" do
       config    = Configuration.new

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -92,6 +92,79 @@ module Beetle
       assert_equal bunny_mock, pub.send(:new_bunny)
     end
 
+    test "new bunnies should be created with timeouts configured" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+
+      config.publisher_connect_timeout = 30
+      config.publisher_read_timeout = 15
+      config.publisher_read_response_timeout = 10
+      config.publisher_write_timeout = 20
+
+      client = Client.new(config)
+      pub = Publisher.new(client)
+
+      bunny_mock = mock("dummy_bunny")
+      expected_bunny_options = {
+        connection_timeout: 30,
+        write_timeout: 20,
+        read_timeout: 15,
+        continuation_timeout: 10_000
+      }
+
+      Bunny
+        .expects(:new)
+        .with { |actual| expected_bunny_options.all? { |k, v| actual[k] == v }  } # match our subset of options
+        .returns(bunny_mock)
+
+      bunny_mock.expects(:start)
+      assert_equal bunny_mock, pub.send(:new_bunny)
+    end
+
+    test "new bunnies with hearbeat configuration" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+
+      config.publisher_heartbeat = 10
+
+      client = Client.new(config)
+      pub = Publisher.new(client)
+
+      bunny_mock = mock("dummy_bunny")
+      expected_bunny_options = {
+        heartbeat: 10
+      }
+
+      Bunny
+        .expects(:new)
+        .with { |actual| expected_bunny_options.all? { |k, v| actual[k] == v }  } # match our subset of options
+        .returns(bunny_mock)
+
+      bunny_mock.expects(:start)
+      assert_equal bunny_mock, pub.send(:new_bunny)
+    end
+
+    test "new bunnies with custom session error handler" do
+      config = Configuration.new
+      config.servers = 'localhost:5672'
+      client = Client.new(config)
+      pub = Publisher.new(client)
+
+      bunny_mock = mock("dummy_bunny")
+
+      Bunny
+        .expects(:new)
+        .with do |actual|
+          actual[:session_error_handler].is_a?(Beetler::PublisherSessionErrorHandler)
+        end
+        .returns(bunny_mock)
+
+      bunny_mock.expects(:start)
+      assert_equal bunny_mock, pub.send(:new_bunny)
+    end
+
+
+
     test "initially there should be no bunnies" do
       assert_equal({}, @pub.instance_variable_get("@bunnies"))
     end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -155,7 +155,7 @@ module Beetle
       Bunny
         .expects(:new)
         .with do |actual|
-          actual[:session_error_handler].is_a?(Beetler::PublisherSessionErrorHandler)
+          actual[:session_error_handler].is_a?(Beetle::PublisherSessionErrorHandler)
         end
         .returns(bunny_mock)
 


### PR DESCRIPTION
This allows to set different timeouts for:

* socket read / write
* response from server for requests that expect a response

Before this covered by a single `publishing_timeout` setting which was defaulted to 5 seconds.
We retained that default here but now we have the ability to tweak the timeouts independently.

In particular we'd like to be able to tweak socket timeouts independent of continuation timeout.