### PR TITLE
Make sure transport is closed on stop

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -370,7 +370,7 @@ module Beetle
 
       # kill heartbeat sender if it exists
       begin
-        bunny.__send__ :maybe_shutdown_heartbeat_sender 
+        bunny.__send__(:maybe_shutdown_heartbeat_sender)
       rescue StandardError => e
         partial_failures << e
         logger.warn "Beetle: error shutting down heartbeat sender: #{e}"
@@ -378,7 +378,7 @@ module Beetle
 
       # kill reader loop if it exists
       begin
-        reader_loop = bunny.__send__ :reader_loop
+        reader_loop = bunny.__send__(:reader_loop)
         reader_loop.kill if reader_loop
       rescue StandardError => e
         partial_failures << e
@@ -389,10 +389,17 @@ module Beetle
       # it's fine that we don't have a reader loop here anymore, since we don't expect
       # an answer from the server
       begin
-        bunny.__send__ :close_connection, false
+        bunny.__send__(:close_connection, false)
       rescue StandardError => e
         partial_failures << e
         logger.warn "Beetle: error closing connection to server: #{e}"
+      end
+
+      begin
+        bunny.transport.close 
+      rescue StandardError => e
+        partial_failures << e
+        logger.warn "Beetle: error closing transport to server: #{e}"
       end
 
       return if partial_failures.empty?


### PR DESCRIPTION
This makes sure that we also close the transport on stop.
This is required to cleanup any sockets.
I also added an integration test for the method that stops the bunny forcefully, since we rely on some internal APIs, we want to make sure they exist and work as expected.