### PR TITLE
Make sure we actually timeout

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -19,7 +19,7 @@ module Beetle
     end
 
     def current_server_restarts
-       @bunny_stops[@server] || 0
+      @bunny_stops[@server] || 0
     end 
 
     def exceptions?
@@ -273,7 +273,12 @@ module Beetle
         :session_error_handler => error_handler
       )
 
-      b.start 
+      # On AWS we can connect to an endpoint that terminates the TLS connection (an NLB)
+      # Which then might fail to connect to the RabbitMQ server, which leads to timeout after 10 seconds.
+      # Which we can not change on the socket level
+      Timeout.timeout(@client.config.publisher_connect_timeout) do
+        b.start 
+      end
       b
 
     # bunny.start may raise NoMethodError if the transport isn't functioning


### PR DESCRIPTION
On AWS we have a special situation in which when we try to establish a connection from a POD to a rabbitmq server we don't have access to. In this case we can connect to a node that terminates the TLS connection, but then it fails to forward the traffic to the rabbitmq server. This means that we run into a timeout of 10 seconds, which we can not change on the socket level.

Here is the s_client output that shows the behavior
```
root@central-messaging-testlab-66f5b7f74f-4wx4w:/app# time openssl s_client -connect b-dce17ddc-d5ad-4486-9216-f645e215fdd3.mq.eu-west-1.on.aws:5671
CONNECTED(00000003)
depth=2 C = US, O = Amazon, CN = Amazon Root CA 1
verify return:1
depth=1 C = US, O = Amazon, CN = Amazon RSA 2048 M03
verify return:1
depth=0 CN = *.mq.eu-west-1.on.aws
verify return:1
---
Certificate chain
 0 s:CN = *.mq.eu-west-1.on.aws
   i:C = US, O = Amazon, CN = Amazon RSA 2048 M03
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Mar 21 00:00:00 2025 GMT; NotAfter: Apr 19 23:59:59 2026 GMT
 1 s:C = US, O = Amazon, CN = Amazon RSA 2048 M03
   i:C = US, O = Amazon, CN = Amazon Root CA 1
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Aug 23 22:26:04 2022 GMT; NotAfter: Aug 23 22:26:04 2030 GMT
 2 s:C = US, O = Amazon, CN = Amazon Root CA 1
   i:C = US, ST = Arizona, L = Scottsdale, O = "Starfield Technologies, Inc.", CN = Starfield Services Root Certificate Authority - G2
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: May 25 12:00:00 2015 GMT; NotAfter: Dec 31 01:00:00 2037 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIF1jCCBL6gAwIBAgIQCtz1FlVzGMn8rc7BBE0u2TANBgkqhkiG9w0BAQsFADA8
MQswCQYDGQW1hem9uMRwwGgYDVQQDExNBbWF6b24g
UlNBIDIwNDggTTAzMB4XDTI1MDMyMTAwMDAwMFoXDTI2MDQxOTIzNTk1OVowIDEe
MBwGA1UEAwwVKi5tcS5ldS13ZXN0LTEub24uYXdzMIIBIjANBgkqhkiG9w0BAQEF
AAOCAQ8AMIIBCgKCAQEAnedYy6C1rhohABREdMiFTg4zA8rqBAQPOkspfAtevZ01
O/ilur0dG7X1pvtbsNtc+f7q0rFBJuTsylpYABmE+hejQMxmvPWRBs0g/IeUrwV9
7bqEx+W7RZR7d9IYufTPpVpuZ4DONjj2O+6BE0bg6kfRDjt1/OrbsIN3S92I3p3z
xUREB8RslxPliZEdeY0zrWduMuljP3QvlCaKq+frwo4Dqu
c2Aj83k/h7dXW08V86o3iCqhXZxV3laNuOKZL3R+i+W7AEp1s4Kby19+BM+NWdOV
lCFDDjjSc5qhxXSijx1tQ/aeEyNfVz4zQIDAQABo4IC7jCCAuowHwYD
VR0jBBgwFoAUVdkYX9IczAHhWLS+q9lVQgHXLgIwHQYDVR0OBBYEFAIdq7dbmtSp
b92WPKKoCxIi1d9+MCAGA1UdEQQZMBeCFSoubXEuZXUtd2VzdC0xLm9uLmF3czAT
BgNVHSAEDDAKMAgGBmeBDAECATAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYI
KwYBBQUHAwEGCCsGAQUFBwMCMDsGA1UdHwQ0MDIwMKAuoCyGKmh0dHA6Ly9jcmwu
cjJtMDMuYW1hem9udHJ1c3QuY29tL3IybTAzLmNybDB1BggrBgEFBQcBAQRpMGcw
LQYIKwYBBQUHMAGGIWh0dHA6Ly9vY3NwLnIybTAzLmFtYXpvbnRydXN0LmNvbTA2
BggrBgEFBQcwAoYqaHR0cDovL2NydC5yMm0wMy5hbWF6b250cnVzdC5jb20vcjJt
MDMuY2VyMAwGA1UdEwEB/wQCMAAwggF+BgorBgEEAdZ5AgQCBIIBbgSCAWoBaAB1
AA5XlLzzrqk+MxssmQez95Dfm8I9cTIl3SGpJaxhxU4hAAABlbpvqHEAAAQDAEYw
RAIgWqMOcFojWDz4Wj0hna21N8Cj5nBAAEmTILbNx0ckPdcCICcQhArUJf5Gm0Hi
CL2z7f7pdlyJVfuslDxIxBniVIwfAHYAZBHEbKQS7KeJHKICLgC8q08oB9QeNSer
6v7VA8l9zfAAAAGVum+osQAABAMARzBFAiBrIFQJTWFibGIMfMfvIHZ3/vtfg2xG
uvnUKHFBNijQxgIhAP6C1vji3cuyEwEYe9n+9LitvFMVFt/+cXhsgeG3Qrs+AHcA
SZybad4dfOz8Nt7Nh2SmuFuvCoeAGdFVUvvp6ynd+MMAAAGVum+owwAABAMASDBG
AiEA/1QlOBZvTL602vpDzy84nnb6kUz/iYbUqEobH25CWAMCIQD7Zu2pwDwneoWQ
pRYhOYKJ7rK7m7FSm3lXXlfV1bxGdDANBgkqhkiG9w0BAQsFAAOCAQEAD53NWldZ
qoKTH5dR6JkVgLs781+W65dlrP7fO7pgzyG8Vko7y+z5TrPUN5Dq4KlfiK6FlY92
eio6eEx2zMBZCyHpLio9oBWD48m8p5IQmrE2YW2ix/gbw4we3wfq+mNh7llRpfx7
zsHkNiCDtxUXN6nyT4gX53x0DyS9ZwT5ODwfmBy/RW85w4NJteZcNwpuBVS4CYpr
2vHi/VhQq55os3idUyAA2IKbDInBAGCVyxUXrVcYKOUjTMnVou/ZZ0asaRjVQKjS
pIIMTSe4dNUd9qONfnBN4rHJc9/hMyfSFvgEGwjEwEvcdkqXd/GqT67+YXl875pc
cJXGWohkRX2zyQ==
-----END CERTIFICATE-----
subject=CN = *.mq.eu-west-1.on.aws
issuer=C = US, O = Amazon, CN = Amazon RSA 2048 M03
---
Acceptable client certificate CA names
C = US, ST = Arizona, L = Scottsdale, O = "Starfield Technologies, Inc.", CN = Starfield Services Root Certificate Authority - G2
C = US, O = Amazon, CN = Amazon RSA 2048 M03
C = US, O = Amazon, CN = Amazon Root CA 1
Client Certificate Types: ECDSA sign, RSA sign, DSA sign
Requested Signature Algorithms: ECDSA+SHA512:RSA-PSS+SHA512:RSA-PSS+SHA512:RSA+SHA512:ECDSA+SHA384:RSA-PSS+SHA384:RSA-PSS+SHA384:RSA+SHA384:ECDSA+SHA256:RSA-PSS+SHA256:RSA-PSS+SHA256:RSA+SHA256
Shared Requested Signature Algorithms: ECDSA+SHA512:RSA-PSS+SHA512:RSA-PSS+SHA512:RSA+SHA512:ECDSA+SHA384:RSA-PSS+SHA384:RSA-PSS+SHA384:RSA+SHA384:ECDSA+SHA256:RSA-PSS+SHA256:RSA-PSS+SHA256:RSA+SHA256
Peer signing digest: SHA256
Peer signature type: RSA-PSS
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 4595 bytes and written 465 bytes
Verification: OK
---
New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-AES256-GCM-SHA384
    Session-ID: 990C94EE25464253B71C17CB7A3B99EEC35B5ADCEFED4893C9751
    Session-ID-ctx: 
    Master-Key: 5DC4A72B676D789474A2485A4D31E2B5E06875AD130748EAF364A41E2BF382505C5917FA29CEB
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    Start Time: 1751273821
    Timeout   : 7200 (sec)
    Verify return code: 0 (ok)
    Extended master secret: no
---
closed

real    0m10.018s
user    0m0.010s
sys     0m0.000s
```

I think it would also be possible to update `bunny` to use `connect_async` from the OpenSSL socket and then follow up with an IO.select with timeout on the async socket. This would however require a change in bunny or a monkey-patch from beetle. (We'll git it go inside this PR to see if it works).