### PR TITLE
Publisher handles all errors in publish the same

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -19,7 +19,7 @@ module Beetle
     end
 
     def current_server_restarts
-       @bunny_stops[@server] || 0
+      @bunny_stops[@server] || 0
     end 
 
     def exceptions?
@@ -87,7 +87,7 @@ module Beetle
 
         logger.debug "Beetle: message sent!"
         published = 1
-      rescue *recoverable_exceptions => e
+      rescue StandardError => e 
         log_publishing_exception(exception: e, tries: tries, server: @server, message_name: message_name, exchange_name: exchange_name)
         stop!(e)
         tries -= 1
@@ -132,7 +132,7 @@ module Beetle
           exchange(exchange_name).publish(data, opts.dup)
           published << @server
           logger.debug "Beetle: message sent (#{published})!"
-        rescue *recoverable_exceptions => e
+        rescue StandardError => e 
           log_publishing_exception(exception: e, tries: tries, server: @server, message_name: message_name, exchange_name: exchange_name)
           stop!(e)
           if (tries += 1) == 1
@@ -196,18 +196,6 @@ module Beetle
     end
 
     private
-
-    def recoverable_exceptions
-      @recoverable_exceptions ||= [
-        AMQ::Protocol::Error,
-        Bunny::Exception, 
-        Errno::EHOSTUNREACH, 
-        Errno::ECONNRESET, 
-        Errno::ETIMEDOUT, 
-        Timeout::Error,
-        Beetle::PublisherConnectError
-      ]
-    end
 
     def bunny
       @bunnies[@server] ||= new_bunny


### PR DESCRIPTION
In all cases we want to play safe, reset the publishing state, and retry if possible. Before this change there was the chance, that unknown errors that could occur would not be handled correctly, again leaving room rogue threads.

This simplifies the error handling of publish to crash-recovery for all errors.