### PR TITLE
Improve resilience of subscribers when connecting to AWS AmazonMQ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gem "hiredis-client"
 # gem 'bunny', '=0.7.10', :path => "#{ENV['HOME']}/src/bunny"
 gem 'pry'
 gem 'toxiproxy'
+
+group :test do
+  gem "em-synchrony"
+end

--- a/lib/beetle/amqp_session.rb
+++ b/lib/beetle/amqp_session.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'amqp'
+
+module Beetle
+  # Our subclass of AMQP::Session which fixes a bug in the ruby AMQP gem
+  class AMQPSession < ::AMQP::Session
+    # we have to fix a bug in ruby AMQP which mistakes the heartbeat timeout for the heartbeat interval
+    def heartbeat_interval
+      return 0 if @heartbeat_interval.nil? || @heartbeat_interval <= 0
+
+      [(@heartbeat_interval / 2) - 1, 1].max
+    end
+
+  end
+end

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -246,7 +246,7 @@ module Beetle
 
       self.update_queue_properties_synchronously = false
 
-      self.subscriber_connect_timeout = 15 # seconds
+      self.subscriber_connect_timeout = 20 # seconds
       self.subscriber_reconnect_delay = 10 # seconds
       self.subscriber_reconnect_on_authentication_failure = false
       self.subscriber_heartbeat = 0

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -163,6 +163,9 @@ module Beetle
     # the delay in seconds between reconnects on connection loss (defaults to <tt>10</tt>)
     attr_accessor :subscriber_reconnect_delay
 
+    # # whether to reconnect on authentication failure (defaults to <tt>false</tt>)
+    attr_accessor :subscriber_reconnect_on_authentication_failure
+
     # the heartbeats to use for the subscriber connection (defaults to <tt>0</tt>)
     attr_accessor :subscriber_heartbeat
 
@@ -243,8 +246,9 @@ module Beetle
 
       self.update_queue_properties_synchronously = false
 
-      self.subscriber_connect_timeout = 5 # seconds
+      self.subscriber_connect_timeout = 15 # seconds
       self.subscriber_reconnect_delay = 10 # seconds
+      self.subscriber_reconnect_on_authentication_failure = false
       self.subscriber_heartbeat = 0
 
       self.tmpdir = "/tmp"

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -245,8 +245,6 @@ module Beetle
 
       self.subscriber_connect_timeout = 20 # seconds
       self.subscriber_reconnect_delay = 10 # seconds
-      self.subscriber_reconnect_on_authentication_failure = false
-      self.subscriber_max_authentication_failures = 3
       self.subscriber_heartbeat = 0
 
       self.tmpdir = "/tmp"

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -163,8 +163,11 @@ module Beetle
     # the delay in seconds between reconnects on connection loss (defaults to <tt>10</tt>)
     attr_accessor :subscriber_reconnect_delay
 
-    # # whether to reconnect on authentication failure (defaults to <tt>false</tt>)
+    # whether to reconnect on authentication failure (defaults to <tt>false</tt>)
     attr_accessor :subscriber_reconnect_on_authentication_failure
+
+    # the maximum number of authentication failures before giving up and stopping the reactor
+    attr_accessor :subscriber_max_authentication_failures
 
     # the heartbeats to use for the subscriber connection (defaults to <tt>0</tt>)
     attr_accessor :subscriber_heartbeat

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -163,12 +163,6 @@ module Beetle
     # the delay in seconds between reconnects on connection loss (defaults to <tt>10</tt>)
     attr_accessor :subscriber_reconnect_delay
 
-    # whether to reconnect on authentication failure (defaults to <tt>false</tt>)
-    attr_accessor :subscriber_reconnect_on_authentication_failure
-
-    # the maximum number of authentication failures before giving up and stopping the reactor
-    attr_accessor :subscriber_max_authentication_failures
-
     # the heartbeats to use for the subscriber connection (defaults to <tt>0</tt>)
     attr_accessor :subscriber_heartbeat
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -249,6 +249,7 @@ module Beetle
       self.subscriber_connect_timeout = 20 # seconds
       self.subscriber_reconnect_delay = 10 # seconds
       self.subscriber_reconnect_on_authentication_failure = false
+      self.subscriber_max_authentication_failures = 3
       self.subscriber_heartbeat = 0
 
       self.tmpdir = "/tmp"

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -281,7 +281,7 @@ module Beetle
     def connect_server(settings)
       server = server_from_settings settings
       logger.info "Beetle: connecting to rabbit #{server}"
-      binding.irb
+
       AMQPSession.connect(settings) do |connection|
         logger.info "Beetle: connected to rabbit #{server}. Heartbeat timeout: #{@client.config.subscriber_heartbeat}, interval: #{connection.heartbeat_interval} in seconds."
         connection.on_tcp_connection_loss(&method(:on_tcp_connection_loss))

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -261,9 +261,10 @@ module Beetle
     end
 
     def on_tcp_connection_loss(connection, settings)
-      # reconnect in 10 seconds, without enforcement
       logger.warn "Beetle: lost connection: #{server_from_settings(settings)}. reconnecting."
-      connection.reconnect(false, 10)
+      EM.add_timer(@client.config.subscriber_reconnect_delay) do
+        connection.reconnect(true, 0)
+      end
     end
 
     def connect_server(settings)

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -1,6 +1,7 @@
 require 'amqp'
 
 module Beetle
+  # Our subclass of AMQP::Session which fixes a bug in the ruby AMQP gem
   class AMQPSession < AMQP::Session
     # we have to fix a bug in ruby AMQP which mistakes the heartbeat timeout for the heartbeat interval
     def heartbeat_interval

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -1,17 +1,7 @@
 require 'amqp'
+require_relative 'amqp_session'
 
 module Beetle
-  # Our subclass of AMQP::Session which fixes a bug in the ruby AMQP gem
-  class AMQPSession < AMQP::Session
-    # we have to fix a bug in ruby AMQP which mistakes the heartbeat timeout for the heartbeat interval
-    def heartbeat_interval
-      return 0 if @heartbeat_interval.nil? || @heartbeat_interval <= 0
-
-      [(@heartbeat_interval / 2) - 1, 1].max
-    end
-
-  end
-
   class Subscriber < Base
 
     attr_accessor :tracing
@@ -291,6 +281,7 @@ module Beetle
     def connect_server(settings)
       server = server_from_settings settings
       logger.info "Beetle: connecting to rabbit #{server}"
+      binding.irb
       AMQPSession.connect(settings) do |connection|
         logger.info "Beetle: connected to rabbit #{server}. Heartbeat timeout: #{@client.config.subscriber_heartbeat}, interval: #{connection.heartbeat_interval} in seconds."
         connection.on_tcp_connection_loss(&method(:on_tcp_connection_loss))

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -255,9 +255,13 @@ module Beetle
 
     def on_possible_authentication_failure
       Proc.new do |settings|
-        logger.error "Beetle: possible authentication failure, or server overloaded: #{server_from_settings(settings)}. shutting down!"
+        logger.error "Beetle: possible authentication failure, or server overloaded: #{server_from_settings(settings)}. shutting down! pid=#{Process.pid} user=#{user_from_settings(settings)} "
         stop!
       end
+    end
+
+    def user_from_settings(settings)
+      settings[:user]
     end
 
     def on_tcp_connection_loss(connection, settings)
@@ -271,6 +275,7 @@ module Beetle
       server = server_from_settings settings
       logger.info "Beetle: connecting to rabbit #{server}"
       AMQP.connect(settings) do |connection|
+        logger.info "Beetle: connected to rabbit #{server}. Heartbeat interval configured: #{@client.config.subscriber_heartbeat}, actual: #{connection.heartbeat_interval} seconds."
         connection.on_tcp_connection_loss(&method(:on_tcp_connection_loss))
         @connections[server] = connection
         open_channel_and_subscribe(connection, settings)

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -269,7 +269,7 @@ module Beetle
         server = server_from_settings(settings)
         auhthentication_failures = @authentication_failures[server] || 0
 
-        logger.error "Beetle: possible authentication failure, or server overloaded: #{server}. shutting down! pid=#{Process.pid} user=#{user_from_settings(settings)} auhtentication_failures=#{auhthentication_failures}."
+        logger.error "Beetle: possible authentication failure, or server overloaded: #{server}. Shutting down. This could also mean that the subscriber_connect_timeout is too low.  pid=#{Process.pid} user=#{user_from_settings(settings)} auhtentication_failures=#{auhthentication_failures}."
 
         if reconnect_on_authentication_failure? && auhthentication_failures < @client.config.subscriber_max_authentication_failures
           EM::Timer.new(@client.config.subscriber_reconnect_delay) { connect_server(settings) }
@@ -303,7 +303,7 @@ module Beetle
       server = server_from_settings settings
       logger.info "Beetle: connecting to rabbit #{server}"
       AMQPSession.connect(settings) do |connection|
-        logger.info "Beetle: connected to rabbit #{server}. Heartbeat interval configured: #{@client.config.subscriber_heartbeat}, actual: #{connection.heartbeat_interval} seconds."
+        logger.info "Beetle: connected to rabbit #{server}. Heartbeat timeout: #{@client.config.subscriber_heartbeat}, interval: #{connection.heartbeat_interval} in seconds."
         connection.on_tcp_connection_loss(&method(:on_tcp_connection_loss))
         connection.on_skipped_heartbeats(&method(:on_skipped_heartbeats))
 

--- a/test/beetle/message_test.rb
+++ b/test/beetle/message_test.rb
@@ -2,7 +2,6 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 
 module Beetle
-
   class RedeliveryInformationTest < Minitest::Test
     def logger
       Logger.new(File::NULL)

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -454,7 +454,9 @@ module Beetle
     test "possible authentication failure causes subscriber to exit" do
       cb = @sub.send(:on_possible_authentication_failure)
       @sub.expects(:stop!)
-      @sub.logger.expects(:error).with("Beetle: possible authentication failure, or server overloaded: mickey:42. shutting down! pid=#{Process.pid} user= ")
+      @sub.logger.expects(:error).with do |msg|
+        assert_match(/Beetle: possible authentication failure, or server overloaded: mickey:42. shutting down! pid=\d+ user= /, msg)
+      end
       cb.call({:host => "mickey", :port => 42})
     end
 

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -469,7 +469,7 @@ module Beetle
       connection.expects(:reconnect).with(true, 0)
 
       EM.expects(:add_timer).with(10).yields
-      @sub.logger.expects(:warn).with("Beetle: lost connection: mickey:42. reconnecting.")
+      @sub.logger.expects(:warn).with("Beetle: lost connection: mickey:42. Reconnecting in 10 seconds.")
       @sub.send(:on_tcp_connection_loss, connection, {:host => "mickey", :port => 42})
     end
 


### PR DESCRIPTION
This improves the subscriber of the library on the following fronts:

* increase the default subscriber connection timeout 
* reconnect handling is fixed to prevent reconnect storm
* heartbeat interval is adjusted to be aligned with heartbeat timeout (works around a bug in ruby amqp)
* improve logging for subscriber


These changes are required to match the demands of a hybrid environment where some brokers are fast and network latency is low, but some others are slower and latency for everything is higher.  This led to repeated pod restarts on our platform because connections have been accidentally marked as authentication failed, when in fact they timed out before the authentication response could be processed. 

This is partly due to the fact that the event machine reactor is blocked due to costly synchronous setup code on a slow broker.

