### PR TITLE
Attach info about app to connection

### DIFF
--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -199,6 +199,7 @@ module Beetle
     end
 
     def connection_name
+      return "undefined" unless @connection_name
       "#{@connection_name}-#{Process.pid}-#{SecureRandom.hex(3)}"
     end
 

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -188,7 +188,7 @@ module Beetle
     attr_accessor :publisher_lazy_queue_setup
 
     # meta data for the connection, used to identify the application that holds the connection in the RabbitMQ management UI
-    attr_accessor :connection_name
+    attr_writer :connection_name
 
     # returns the configured amqp brokers
     def brokers
@@ -196,6 +196,10 @@ module Beetle
         'servers' => servers,
         'additional_subscription_servers' => additional_subscription_servers
       }
+    end
+
+    def connection_name
+      "#{@connection_name}-#{Process.pid}-#{SecureRandom.hex(3)}"
     end
 
     def initialize # :nodoc:

--- a/lib/beetle/configuration.rb
+++ b/lib/beetle/configuration.rb
@@ -187,6 +187,9 @@ module Beetle
     # this means that on first publish to an exchange we declare all the queues that are bound to it
     attr_accessor :publisher_lazy_queue_setup
 
+    # meta data for the connection, used to identify the application that holds the connection in the RabbitMQ management UI
+    attr_accessor :connection_name
+
     # returns the configured amqp brokers
     def brokers
       {

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -270,7 +270,8 @@ module Beetle
         :recovery_attempts => 0,
         # register our own error handler, because the default is Thread.current which is a super bad idea
         # because it will raise exceptions originating in background threads (reader_loop, heartbeat_sender) in the main thread
-        :session_error_handler => error_handler
+        :session_error_handler => error_handler,
+        :connection_name => @client.config.connection_name
       )
 
       b.start 

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -243,6 +243,9 @@ module Beetle
         :heartbeat => @client.config.subscriber_heartbeat,
         :on_tcp_connection_failure => on_tcp_connection_failure,
         :on_possible_authentication_failure => on_possible_authentication_failure,
+        client_properties: {
+          connection_name: @client.config.connection_name
+        }
       }
     end
 

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -39,6 +39,7 @@ module Beetle
     end
 
     test "new bunnies should be created using custom connection options and they should be started" do
+      SecureRandom.stubs(:hex).with(3).returns("abc123")
       config = Configuration.new
       config.servers = 'localhost:5672'
       config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
@@ -60,7 +61,7 @@ module Beetle
         connection_timeout: 5,
         channel_max: 2047,
         heartbeat: :server,
-        connection_name: "my_app_name"
+        connection_name: "my_app_name-#{Process.pid}-abc123"
       }
 
       Bunny

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -42,6 +42,7 @@ module Beetle
       config = Configuration.new
       config.servers = 'localhost:5672'
       config.server_connection_options["localhost:5672"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
+      config.connection_name = "my_app_name"
       client = Client.new(config)
       pub = Publisher.new(client)
 
@@ -58,7 +59,8 @@ module Beetle
         continuation_timeout: 5_000,
         connection_timeout: 5,
         channel_max: 2047,
-        heartbeat: :server
+        heartbeat: :server,
+        connection_name: "my_app_name"
       }
 
       Bunny

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -432,18 +432,19 @@ module Beetle
       @config.servers = "mickey:42"
       @config.connection_name = "test_connection"
       @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
-
+      SecureRandom.stubs(:hex).with(3).returns("abc123")
       @client = Client.new(@config)
       @sub = @client.send(:subscriber)
       @sub.send(:set_current_server, "mickey:42")
       @settings = @sub.send(:connection_settings)
     end
 
+
     test "connection settings should use current host, port, specify connection failure callback and connection name" do
       assert_equal "mickey", @settings[:host]
       assert_equal 42, @settings[:port]
       assert @settings.has_key?(:on_tcp_connection_failure)
-      assert_equal "test_connection", @settings[:client_properties][:connection_name]
+      assert_equal "test_connection-#{Process.pid}-abc123", @settings[:client_properties][:connection_name]
     end
 
     test "tcp connection failure should try to connect again after 10 seconds" do

--- a/test/beetle/subscriber_test.rb
+++ b/test/beetle/subscriber_test.rb
@@ -430,6 +430,7 @@ module Beetle
     def setup
       @config = Beetle::Configuration.new
       @config.servers = "mickey:42"
+      @config.connection_name = "test_connection"
       @config.server_connection_options["mickey:42"] = { user: "john", pass: "doe", vhost: "test", ssl: false }
 
       @client = Client.new(@config)
@@ -438,10 +439,11 @@ module Beetle
       @settings = @sub.send(:connection_settings)
     end
 
-    test "connection settings should use current host and port and specify connection failure callback" do
+    test "connection settings should use current host, port, specify connection failure callback and connection name" do
       assert_equal "mickey", @settings[:host]
       assert_equal 42, @settings[:port]
       assert @settings.has_key?(:on_tcp_connection_failure)
+      assert_equal "test_connection", @settings[:client_properties][:connection_name]
     end
 
     test "tcp connection failure should try to connect again after 10 seconds" do


### PR DESCRIPTION
We need to have a meta information about which app is holding a connection.

Dependency:

https://github.com/new-work/xing-amqp/pull/143