### PR TITLE
Sketch out a phased boot for subscribers

### DIFF
--- a/lib/beetle/await_latch.rb
+++ b/lib/beetle/await_latch.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'eventmachine'
+
+module Beetle
+  include EM::Deferrable
+
+  class AwaitLatch
+    def initialize(expected_count, timeout = nil)
+      @expected_count = expected_count
+      @timeout = timeout
+      @completed_count = 0
+      @results = []
+
+      return unless timeout
+
+      EM.add_timer(timeout) do
+        self.fail(:timeout) unless completed?
+      end
+    end
+
+    def succeed_one(result)
+      return if @completed >= @expected
+
+      @results << result
+      @completed += 1
+
+      succeed(@results) if completed?
+    end
+
+    def fail_one(_error)
+      @results << nil
+      @completed += 1
+
+      succeed(@results) if completed?
+    end
+
+    def completed?
+      @completed_count >= @expected_count
+    end
+  end
+end

--- a/lib/beetle/await_latch.rb
+++ b/lib/beetle/await_latch.rb
@@ -3,13 +3,13 @@
 require 'eventmachine'
 
 module Beetle
-  include EM::Deferrable
-
   class AwaitLatch
-    def initialize(expected_count, timeout = nil)
-      @expected_count = expected_count
+    include EM::Deferrable
+
+    def initialize(expected_count, timeout: nil)
+      @expected = expected_count
       @timeout = timeout
-      @completed_count = 0
+      @completed = 0
       @results = []
 
       return unless timeout
@@ -36,7 +36,7 @@ module Beetle
     end
 
     def completed?
-      @completed_count >= @expected_count
+      @completed >= @expected
     end
   end
 end

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -58,7 +58,6 @@ module Beetle
         connect_latch.callback do |servers|
           # we have all connections established that we could establish
           bind_latch = AwaitLatch.new(servers.size, timeout: 5)
-          puts @channels.inspect
 
           servers.each do |server_name|
             establish_queue_bindings(server_name)
@@ -301,7 +300,7 @@ module Beetle
     def on_tcp_connection_failure
       Proc.new do |settings|
         logger.warn "Beetle: connection failed: #{server_from_settings(settings)}. Timeout: #{@client.config.subscriber_connect_timeout} seconds. Delay before retry: #{@client.config.subscriber_reconnect_delay} seconds."
-        EM::Timer.new(@client.config.subscriber_reconnect_delay) { connect_server(settings) }
+        EM::Timer.new(@client.config.subscriber_reconnect_delay) { connect_server_immediately(settings) }
       end
     end
 

--- a/lib/beetle/subscriber.rb
+++ b/lib/beetle/subscriber.rb
@@ -174,7 +174,6 @@ module Beetle
 
     def subscribe_queues(queues)
       queues.each do |name|
-        puts "Subscribing queue: #{name}"
         subscribe(name) if @handlers.include?(name)
       end
     end


### PR DESCRIPTION
This is a draft / experiment how much complexity we add if we establish a phased startup of consumers.
The current implementation establishes and starts a consumer as soon as it is connected, while there are still outstanding connections to other servers

If a server is slow to connect it can run into timeouts because the reactor is busy or blocked, by already started servers.

## Complexity 


I think a proper implementation would have to attempt a phased startup but also allow to fallback to let connections start as they come. 

so creating a latch to wait on for servers in each of the 3 phases (connect, bind, subscribe). I will give it a try but I am quite confident that becomes complex quickly.

I will investigate a bit more if the problems we see are actually justifying that level of change, 

