### PR TITLE
Just always apply a timeout for BunnySession#start

### DIFF
--- a/lib/beetle/bunny_session.rb
+++ b/lib/beetle/bunny_session.rb
@@ -16,6 +16,8 @@ module Beetle
       #
       # This means that if the TLS negotiation takes longer than the connect timeout,
       # the connection will hang long (10 seconds in our observations).
+      #
+      # We add a small buffer to the connect timeout to avoid a race with the socket timeout.
       Timeout.timeout(transport.connect_timeout + 0.2) do
         start
       end


### PR DESCRIPTION
Technically the timeout on startup is only required for TLS connections, but in order to be consistent and to guarantee the same thing for all kinds of connections we just always apply it.