### PR TITLE
Silence TLS warnings

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -239,6 +239,7 @@ module Beetle
         :password              => options[:pass],
         :vhost                 => options[:vhost],
         :tls                   => options[:ssl] || false,
+        :tls_silence_warnings => true,
         :logger                => @client.config.logger,
         :frame_max             => @client.config.frame_max,
         :channel_max           => @client.config.channel_max,

--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -239,7 +239,7 @@ module Beetle
         :password              => options[:pass],
         :vhost                 => options[:vhost],
         :tls                   => options[:ssl] || false,
-        :tls_silence_warnings => true,
+        :tls_silence_warnings  => true,
         :logger                => @client.config.logger,
         :frame_max             => @client.config.frame_max,
         :channel_max           => @client.config.channel_max,


### PR DESCRIPTION
We don't use peer certificate authentication so we can silence warnings about possible errors when this is used.