### PR TITLE
[publisher] Make sure to raise pending errors after publish

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -80,10 +80,8 @@ module Beetle
 
         current_exchange = exchange(exchange_name)
 
-        # exchange declaration might have tainted the connection
-        # we reraise because the channel might no longer be valid and we have to recreate everything
-        reraise_bunny_error!
         current_exchange.publish(data, opts.dup)
+        reraise_bunny_error! # reraise any errors that happened during publishing
 
         if publisher_confirms? && !current_exchange.wait_for_confirms
           logger.warn "Beetle: failed to confirm publishing message #{message_name}"
@@ -136,10 +134,8 @@ module Beetle
           logger.debug "Beetle: trying to send #{message_name}: #{data} with options #{opts}"
           current_exchange = exchange(exchange_name)
 
-          # exchange declaration might have tainted the connection
-          # we reraise because the channel might no longer be valid and we have to recreate everything
-          reraise_bunny_error!
           current_exchange.publish(data, opts.dup)
+          reraise_bunny_error! # reraise any errors that happened during publishing
 
           published << @server
           logger.debug "Beetle: message sent (#{published})!"

--- a/lib/beetle/publisher_session_error_handler.rb
+++ b/lib/beetle/publisher_session_error_handler.rb
@@ -43,7 +43,7 @@ module Beetle
     # @param args [Array] the arguments to raise, usually an exception class and a message
     def raise(*args)
       source_thread = Thread.current # the thread that invoked this method
-      @logger.error "Beetle: bunny session handler error. server=#{@server} raised_from=#{source_thread.inspect}."
+      @logger.warn "Beetle: bunny session handler error. server=#{@server} raised_from=#{source_thread.inspect}."
       @error_mutex.synchronize { @error_args ||= args }
       nil
     end

--- a/lib/beetle/redis_ext.rb
+++ b/lib/beetle/redis_ext.rb
@@ -88,7 +88,7 @@ class Redis #:nodoc:
     module SaneShutdown
       def shutdown
         super
-      rescue RedisClient::CannotConnectError
+      rescue RedisClient::CannotConnectError, Redis::ConnectionError
         nil
       end
     end

--- a/lib/beetle/redis_ext.rb
+++ b/lib/beetle/redis_ext.rb
@@ -88,7 +88,7 @@ class Redis #:nodoc:
     module SaneShutdown
       def shutdown
         super
-      rescue RedisClient::CannotConnectError, Redis::ConnectionError
+      rescue RedisClient::CannotConnectError, ::Redis::CannotConnectError, Errno::ECONNREFUSED
         nil
       end
     end

--- a/test/beetle/publisher_test.rb
+++ b/test/beetle/publisher_test.rb
@@ -716,7 +716,7 @@ module Beetle
       @pub.stop
     end
 
-     test "stop! should should count restarts" do
+    test "stop! counts restarts" do
       bunny = mock("bunny")
       @pub.servers = ["localhost:1111"]
       @pub.send(:select_next_server)
@@ -761,7 +761,7 @@ module Beetle
       assert_equal 1, @pub.publish("mama", @data, @opts)
     end
 
-    test "should raise an exception when confirms return false" do
+    test "should not raise an exception when confirms return false" do
       confirms_sequence = sequence("confirms")
       @pub.servers = ["someserver"]
       @pub.server = "someserver"


### PR DESCRIPTION
This adds code re-raise errors that happen as a result of a publish operation. The most common error that can happen is a broken pipe. 

This increases the odds of handling those errors, but it's not protecting a 100% since there is still the possibility that the error is not updated before we enter the call to reraise. 