### PR TITLE
Also surface errors after exchange declaration

### DIFF
--- a/lib/beetle/publisher.rb
+++ b/lib/beetle/publisher.rb
@@ -79,6 +79,7 @@ module Beetle
         logger.debug "Beetle: trying to send message #{message_name}: #{data} with option #{opts}"
 
         current_exchange = exchange(exchange_name)
+        reraise_bunny_error! # reraise any errors that happened during exchange creation
 
         current_exchange.publish(data, opts.dup)
         reraise_bunny_error! # reraise any errors that happened during publishing
@@ -133,6 +134,7 @@ module Beetle
           bind_queues_for_exchange(exchange_name)
           logger.debug "Beetle: trying to send #{message_name}: #{data} with options #{opts}"
           current_exchange = exchange(exchange_name)
+          reraise_bunny_error! # reraise any errors that happened during exchange creation
 
           current_exchange.publish(data, opts.dup)
           reraise_bunny_error! # reraise any errors that happened during publishing


### PR DESCRIPTION
This now surfaces any pending errors after exchange creation. This happens when a connection has been re-established but then for some reason the setup of exchanges fails again.